### PR TITLE
Add optional product name to bot

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 This project contains a simple Telegram bot for selling products with manual payment approval and two-factor authentication codes.
 
 ## Features
-- Admin can add products with price, credentials, and TOTP secret.
+- Admin can add products with price, credentials, TOTP secret, and an optional name.
 - Users can browse products and submit payment proof.
 - Admin approves purchases and credentials are sent to the buyer.
 - Buyers can obtain a current authenticator code with `/code <product_id>`.
@@ -12,6 +12,12 @@ This project contains a simple Telegram bot for selling products with manual pay
   `/resend`.
 - Stats for each product available via `/stats`.
 - Users can view the admin phone number with `/contact`.
+
+The `/addproduct` command accepts an optional name parameter:
+
+```bash
+/addproduct <id> <price> <username> <password> <secret> [name]
+```
 
 ## Setup
 1. Install dependencies:

--- a/bot.py
+++ b/bot.py
@@ -53,7 +53,10 @@ async def products(update: Update, context: ContextTypes.DEFAULT_TYPE):
         await update.message.reply_text('No products available')
         return
     for pid, info in data['products'].items():
-        text = f"{pid}: {info['price']}\n{info.get('name', '')}"
+        text = f"{pid}: {info['price']}"
+        name = info.get('name')
+        if name:
+            text += f"\n{name}"
         await update.message.reply_text(text, reply_markup=product_keyboard(pid))
 
 
@@ -133,8 +136,9 @@ async def addproduct(update: Update, context: ContextTypes.DEFAULT_TYPE):
         password = context.args[3]
         secret = context.args[4]
     except IndexError:
-        await update.message.reply_text('Usage: /addproduct <id> <price> <username> <password> <secret>')
+        await update.message.reply_text('Usage: /addproduct <id> <price> <username> <password> <secret> [name]')
         return
+    name = " ".join(context.args[5:]) if len(context.args) > 5 else None
     data['products'][pid] = {
         'price': price,
         'username': username,
@@ -142,6 +146,8 @@ async def addproduct(update: Update, context: ContextTypes.DEFAULT_TYPE):
         'secret': secret,
         'buyers': []
     }
+    if name:
+        data['products'][pid]['name'] = name
     save_data(data)
     await update.message.reply_text('Product added')
 


### PR DESCRIPTION
## Summary
- allow specifying a display name when adding a product
- show product names in `/products`
- document the new argument in README

## Testing
- `python -m py_compile bot.py`

------
https://chatgpt.com/codex/tasks/task_e_6871511775e0832db69c97253fca928a