### PR TITLE
Document help and optional name features

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@ This project contains a simple Telegram bot for selling products with manual pay
 - Admin can remove a product with `/deleteproduct <id>`.
 - Stats for each product available via `/stats`.
 - Users can view the admin phone number with `/contact`.
-- Users can view available commands with `/help`.
+- Users can get a list of all commands with `/help`.
 
-The `/addproduct` command accepts an optional name parameter:
+The `/addproduct` command accepts an optional `[name]` argument to label the product:
 
 ```bash
 /addproduct <id> <price> <username> <password> <secret> [name]


### PR DESCRIPTION
## Summary
- merge/rebase onto main (already up-to-date)
- document `/help` command in README
- explain optional `[name]` argument for `/addproduct`

## Testing
- `python -m py_compile bot.py`


------
https://chatgpt.com/codex/tasks/task_e_6871577dd4f4832d8436c7cb53fc7065