### PR TITLE
Add language setting command

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,15 @@ This project contains a simple Telegram bot for selling products with manual pay
 - Users can get a list of all commands with `/help`.
 - Bot messages support both English and Farsi.
 
+### Changing language
+Users can switch their preferred language with:
+
+```bash
+/setlang <code>
+```
+
+Replace `<code>` with a language code such as `en` or `fa`.
+
 The `/addproduct` command accepts an optional `[name]` argument to label the product:
 
 ```bash

--- a/bot.py
+++ b/bot.py
@@ -67,6 +67,21 @@ async def contact(update: Update, context: ContextTypes.DEFAULT_TYPE):
     await update.message.reply_text(tr('admin_phone', lang).format(phone=ADMIN_PHONE))
 
 
+async def setlang(update: Update, context: ContextTypes.DEFAULT_TYPE):
+    """Change the user's language preference."""
+    ensure_lang(context, update.effective_user.id)
+    lang = context.user_data['lang']
+    try:
+        lang_code = context.args[0].lower()
+    except IndexError:
+        await update.message.reply_text(tr('setlang_usage', lang))
+        return
+    data.setdefault('languages', {})[str(update.effective_user.id)] = lang_code
+    save_data(data)
+    context.user_data['lang'] = lang_code
+    await update.message.reply_text(tr('language_set', lang_code))
+
+
 def product_keyboard(product_id: str, lang: str) -> InlineKeyboardMarkup:
     return InlineKeyboardMarkup([[InlineKeyboardButton(tr('buy_button', lang), callback_data=f'buy:{product_id}')]])
 
@@ -366,6 +381,7 @@ async def help_command(update: Update, context: ContextTypes.DEFAULT_TYPE):
         tr('help_user_products', lang),
         tr('help_user_code', lang),
         tr('help_user_contact', lang),
+        tr('help_user_setlang', lang),
         tr('help_user_help', lang),
     ]
     admin_cmds = [
@@ -389,6 +405,7 @@ def main(token: str):
     app.add_handler(CommandHandler('start', start))
     app.add_handler(CommandHandler('contact', contact))
     app.add_handler(CommandHandler('products', products))
+    app.add_handler(CommandHandler('setlang', setlang))
     app.add_handler(CallbackQueryHandler(buy_callback, pattern=r'^buy:'))
     app.add_handler(MessageHandler(filters.PHOTO, handle_photo))
     app.add_handler(CommandHandler('approve', approve))

--- a/botlib/translations.py
+++ b/botlib/translations.py
@@ -55,6 +55,14 @@ TRANSLATIONS = {
         'en': 'Code: {code}',
         'fa': 'کد: {code}'
     },
+    'setlang_usage': {
+        'en': 'Usage: /setlang <code>',
+        'fa': 'استفاده: /setlang <code>'
+    },
+    'language_set': {
+        'en': 'Language updated.',
+        'fa': 'زبان به روز شد.'
+    },
     'addproduct_usage': {
         'en': 'Usage: /addproduct <id> <price> <username> <password> <secret> [name]',
         'fa': 'استفاده: /addproduct <id> <price> <username> <password> <secret> [name]'
@@ -174,6 +182,10 @@ TRANSLATIONS = {
     'help_user_contact': {
         'en': '/contact - view admin phone number',
         'fa': '/contact - مشاهده شماره مدیر'
+    },
+    'help_user_setlang': {
+        'en': '/setlang <code> - change your language',
+        'fa': '/setlang <code> - تغییر زبان'
     },
     'help_user_help': {
         'en': '/help - show this message',


### PR DESCRIPTION
## Summary
- allow users to set preferred language with `/setlang`
- persist language selections in the data file
- document language switching in README

## Testing
- `flake8`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68715e9d08c0832dabb3802e502eba99