### PR TITLE
Add pending and reject commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ This project contains a simple Telegram bot for selling products with manual pay
 - Admin can list and manage buyers.
 - Admin can edit product fields with `/editproduct` and resend credentials with `/resend`.
 - Admin can remove a product with `/deleteproduct <id>`.
+- Admin can list pending purchases with `/pending` and reject them with `/reject`.
 - Stats for each product available via `/stats`.
 - Users can view the admin phone number with `/contact`.
 - Users can get a list of all commands with `/help`.
@@ -74,6 +75,20 @@ for the admin using `-e` flags:
 
 ```bash
 docker run --rm -e ADMIN_ID=<YOUR_ID> -e ADMIN_PHONE=<YOUR_PHONE> accounts-bot <TOKEN>
+```
+
+### Managing pending purchases
+
+List pending purchases:
+
+```bash
+/pending
+```
+
+Reject a pending purchase:
+
+```bash
+/reject <user_id> <product_id>
 ```
 
 ## Development

--- a/botlib/translations.py
+++ b/botlib/translations.py
@@ -35,6 +35,22 @@ TRANSLATIONS = {
         'en': 'Pending purchase not found.',
         'fa': 'خرید در انتظار یافت نشد.'
     },
+    'no_pending': {
+        'en': 'No pending purchases',
+        'fa': 'خرید در انتظاری وجود ندارد'
+    },
+    'pending_entry': {
+        'en': 'User {user_id} waiting for {product_id}',
+        'fa': 'کاربر {user_id} منتظر {product_id}'
+    },
+    'reject_usage': {
+        'en': 'Usage: /reject <user_id> <product_id>',
+        'fa': 'استفاده: /reject <user_id> <product_id>'
+    },
+    'rejected': {
+        'en': 'Purchase rejected.',
+        'fa': 'خرید رد شد.'
+    },
     'code_usage': {
         'en': 'Usage: /code <product_id>',
         'fa': 'استفاده: /code <product_id>'
@@ -194,6 +210,14 @@ TRANSLATIONS = {
     'help_admin_approve': {
         'en': '/approve <user_id> <product_id> - approve a pending purchase',
         'fa': '/approve <user_id> <product_id> - تایید خرید در انتظار'
+    },
+    'help_admin_reject': {
+        'en': '/reject <user_id> <product_id> - reject a pending purchase',
+        'fa': '/reject <user_id> <product_id> - رد خرید در انتظار'
+    },
+    'help_admin_pending': {
+        'en': '/pending - list pending purchases',
+        'fa': '/pending - لیست خریدهای در انتظار'
     },
     'help_admin_addproduct': {
         'en': '/addproduct <id> <price> <username> <password> <secret> [name] - add a product',

--- a/tests/test_reject.py
+++ b/tests/test_reject.py
@@ -1,0 +1,35 @@
+import sys
+from pathlib import Path
+import types
+import asyncio
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from bot import reject, data, ADMIN_ID  # noqa: E402
+
+
+class DummyUpdate:
+    def __init__(self, user_id):
+        self.message = types.SimpleNamespace(
+            from_user=types.SimpleNamespace(id=user_id),
+            reply_text=self._reply,
+        )
+        self.effective_user = self.message.from_user
+        self.replies = []
+
+    async def _reply(self, text):
+        self.replies.append(text)
+
+
+class DummyContext:
+    def __init__(self, args):
+        self.args = args
+        self.user_data = {}
+        self.bot = types.SimpleNamespace()
+
+
+def test_reject_removes_pending():
+    data['pending'] = [{'user_id': 42, 'product_id': 'p1', 'file_id': 'f'}]
+    update = DummyUpdate(ADMIN_ID)
+    context = DummyContext(['42', 'p1'])
+    asyncio.run(reject(update, context))
+    assert data['pending'] == []


### PR DESCRIPTION
## Summary
- list pending purchases with `/pending`
- reject a pending purchase via `/reject`
- document new commands in help text and README
- add tests for the reject command

## Testing
- `flake8`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687160170000832d99a30637e7c36594