### PR TITLE
Enable name editing

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This project contains a simple Telegram bot for selling products with manual pay
 - Admin approves purchases and credentials are sent to the buyer.
 - Buyers can obtain a current authenticator code with `/code <product_id>`.
 - Admin can list and manage buyers.
-- Admin can edit product fields with `/editproduct` and resend credentials with `/resend`.
+- Admin can edit product fields (including the name) with `/editproduct` and resend credentials with `/resend`.
 - Admin can remove a product with `/deleteproduct <id>`.
 - Admin can list pending purchases with `/pending` and reject them with `/reject`.
 - Stats for each product available via `/stats`.

--- a/bot.py
+++ b/bot.py
@@ -216,7 +216,7 @@ async def editproduct(update: Update, context: ContextTypes.DEFAULT_TYPE):
     try:
         pid = context.args[0]
         field = context.args[1]
-        value = context.args[2]
+        value = " ".join(context.args[2:])
     except IndexError:
         await update.message.reply_text(tr('editproduct_usage', lang))
         return
@@ -224,7 +224,7 @@ async def editproduct(update: Update, context: ContextTypes.DEFAULT_TYPE):
     if not product:
         await update.message.reply_text(tr('product_not_found', lang))
         return
-    if field not in {'price', 'username', 'password', 'secret'}:
+    if field not in {'price', 'username', 'password', 'secret', 'name'}:
         await update.message.reply_text(tr('invalid_field', lang))
         return
     product[field] = value

--- a/botlib/translations.py
+++ b/botlib/translations.py
@@ -88,7 +88,7 @@ TRANSLATIONS = {
         'fa': 'محصول اضافه شد'
     },
     'editproduct_usage': {
-        'en': 'Usage: /editproduct <id> <field> <value>',
+        'en': 'Usage: /editproduct <id> <field> <value> (field: price, username, password, secret, name)',
         'fa': 'استفاده: /editproduct <id> <field> <value>'
     },
     'invalid_field': {
@@ -224,8 +224,8 @@ TRANSLATIONS = {
         'fa': '/addproduct <id> <price> <username> <password> <secret> [name] - افزودن محصول'
     },
     'help_admin_editproduct': {
-        'en': '/editproduct <id> <field> <value> - edit product information',
-        'fa': '/editproduct <id> <field> <value> - ویرایش اطلاعات محصول'
+        'en': '/editproduct <id> <field> <value> - edit product info (price, username, password, secret, name)',
+        'fa': '/editproduct <id> <field> <value> - ویرایش مشخصات محصول'
     },
     'help_admin_buyers': {
         'en': '/buyers <product_id> - list buyers of a product',

--- a/tests/test_editproduct.py
+++ b/tests/test_editproduct.py
@@ -1,0 +1,36 @@
+import sys
+from pathlib import Path
+import types
+import asyncio
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from bot import editproduct, data, ADMIN_ID  # noqa: E402
+
+
+class DummyUpdate:
+    def __init__(self, user_id):
+        self.message = types.SimpleNamespace(
+            from_user=types.SimpleNamespace(id=user_id),
+            reply_text=self._reply,
+        )
+        self.effective_user = self.message.from_user
+        self.replies = []
+
+    async def _reply(self, text):
+        self.replies.append(text)
+
+
+class DummyContext:
+    def __init__(self, args):
+        self.args = args
+        self.user_data = {}
+
+
+def test_editproduct_updates_name():
+    data['products'] = {
+        'p1': {'price': '1', 'username': 'u', 'password': 'p', 'secret': 's'}
+    }
+    update = DummyUpdate(ADMIN_ID)
+    context = DummyContext(['p1', 'name', 'New', 'Name'])
+    asyncio.run(editproduct(update, context))
+    assert data['products']['p1']['name'] == 'New Name'


### PR DESCRIPTION
## Summary
- allow `/editproduct` to modify product `name`
- clarify editproduct command messages
- document name editing in README
- test editing product name

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6871641a0050832d86c510190af0a8b1