### PR TITLE
Enforce admin environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,8 +51,9 @@ Example adding a product with a name:
    {"products": {}, "pending": [], "languages": {}}
    ```
 
-   Set the following environment variables explicitly:
-   - `ADMIN_ID` – Telegram user ID of the admin
+   Set the following environment variables **before running the bot**. The
+   application will exit if either is missing or invalid:
+   - `ADMIN_ID` – Telegram user ID of the admin (integer)
    - `ADMIN_PHONE` – phone number shown when users run `/contact`
 3. Run the bot with your bot token:
    ```bash
@@ -71,8 +72,8 @@ Build the image:
 docker build -t accounts-bot .
 ```
 
-Run the container with your bot token. You can also set environment variables
-for the admin using `-e` flags:
+Run the container with your bot token and required admin environment variables
+using `-e` flags:
 
 ```bash
 docker run --rm -e ADMIN_ID=<YOUR_ID> -e ADMIN_PHONE=<YOUR_PHONE> accounts-bot <TOKEN>

--- a/bot.py
+++ b/bot.py
@@ -20,11 +20,18 @@ from botlib.translations import tr
 # Store data.json in the same directory as this script
 DATA_FILE = Path(__file__).resolve().parent / 'data.json'
 try:
-    ADMIN_ID = int(os.getenv("ADMIN_ID", "123456789"))
+    ADMIN_ID = int(os.environ["ADMIN_ID"])
+except KeyError:
+    logging.error("ADMIN_ID environment variable not set")
+    raise SystemExit("ADMIN_ID environment variable not set")
 except ValueError as e:
     logging.error("ADMIN_ID must be an integer")
     raise SystemExit("ADMIN_ID must be an integer") from e
-ADMIN_PHONE = os.getenv("ADMIN_PHONE", "+989152062041")  # manager contact number
+
+ADMIN_PHONE = os.environ.get("ADMIN_PHONE")  # manager contact number
+if not ADMIN_PHONE:
+    logging.error("ADMIN_PHONE environment variable not set")
+    raise SystemExit("ADMIN_PHONE environment variable not set")
 
 logging.basicConfig(level=logging.INFO)
 

--- a/tests/test_editproduct.py
+++ b/tests/test_editproduct.py
@@ -2,6 +2,10 @@ import sys
 from pathlib import Path
 import types
 import asyncio
+import os
+
+os.environ.setdefault("ADMIN_ID", "1")
+os.environ.setdefault("ADMIN_PHONE", "+111")
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 from bot import editproduct, data, ADMIN_ID  # noqa: E402

--- a/tests/test_reject.py
+++ b/tests/test_reject.py
@@ -2,6 +2,10 @@ import sys
 from pathlib import Path
 import types
 import asyncio
+import os
+
+os.environ.setdefault("ADMIN_ID", "1")
+os.environ.setdefault("ADMIN_PHONE", "+111")
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 from bot import reject, data, ADMIN_ID  # noqa: E402


### PR DESCRIPTION
## Summary
- require `ADMIN_ID` and `ADMIN_PHONE` and exit if missing
- document required variables in README
- adapt tests to supply environment variables

## Testing
- `flake8`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68716b9ff368832dbe4a6a60924004d8