### PR TITLE
Add BOT_TOKEN env fallback

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,4 +3,6 @@ WORKDIR /app
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 COPY . .
+# The bot reads the token from the BOT_TOKEN environment variable if no
+# argument is supplied at runtime.
 CMD ["python", "bot.py"]

--- a/README.md
+++ b/README.md
@@ -55,9 +55,12 @@ Example adding a product with a name:
    application will exit if either is missing or invalid:
    - `ADMIN_ID` – Telegram user ID of the admin (integer)
    - `ADMIN_PHONE` – phone number shown when users run `/contact`
-3. Run the bot with your bot token:
+3. Run the bot with your bot token. Pass it as an argument or via the
+   `BOT_TOKEN` environment variable:
    ```bash
    python bot.py <TOKEN>
+   # or
+   BOT_TOKEN=<TOKEN> python bot.py
    ```
 
 This is a minimal implementation and does not include persistent database storage or full error handling.
@@ -76,7 +79,8 @@ Run the container with your bot token and required admin environment variables
 using `-e` flags:
 
 ```bash
-docker run --rm -e ADMIN_ID=<YOUR_ID> -e ADMIN_PHONE=<YOUR_PHONE> accounts-bot <TOKEN>
+docker run --rm -e ADMIN_ID=<YOUR_ID> -e ADMIN_PHONE=<YOUR_PHONE> \
+    -e BOT_TOKEN=<TOKEN> accounts-bot
 ```
 
 ### Managing pending purchases

--- a/bot.py
+++ b/bot.py
@@ -439,7 +439,18 @@ async def help_command(update: Update, context: ContextTypes.DEFAULT_TYPE):
     await update.message.reply_text(text)
 
 
-def main(token: str):
+def get_bot_token(token: str | None) -> str:
+    """Return the bot token from argument or ``BOT_TOKEN`` env var."""
+    token = token or os.environ.get("BOT_TOKEN")
+    if not token:
+        raise SystemExit(
+            "Bot token missing. Pass it as an argument or set BOT_TOKEN environment variable"
+        )
+    return token
+
+
+def main(token: str | None = None):
+    token = get_bot_token(token)
     app = Application.builder().token(token).build()
 
     app.add_handler(CommandHandler('start', start))
@@ -466,7 +477,5 @@ def main(token: str):
 
 
 if __name__ == '__main__':
-    if len(sys.argv) < 2:
-        print('Usage: python bot.py <TOKEN>')
-    else:
-        main(sys.argv[1])
+    token_arg = sys.argv[1] if len(sys.argv) > 1 else None
+    main(token_arg)

--- a/tests/test_token.py
+++ b/tests/test_token.py
@@ -1,0 +1,21 @@
+import sys
+from pathlib import Path
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from bot import get_bot_token  # noqa: E402
+
+
+def test_get_bot_token_argument():
+    assert get_bot_token("cli") == "cli"
+
+
+def test_get_bot_token_env(monkeypatch):
+    monkeypatch.setenv("BOT_TOKEN", "env")
+    assert get_bot_token(None) == "env"
+
+
+def test_get_bot_token_missing(monkeypatch):
+    monkeypatch.delenv("BOT_TOKEN", raising=False)
+    with pytest.raises(SystemExit):
+        get_bot_token(None)


### PR DESCRIPTION
## Summary
- allow reading bot token from `BOT_TOKEN` when argument missing
- document the environment variable in README and Dockerfile
- add tests for token helper

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68716d896e40832da358f69fe4cc52c6