### PR TITLE
Add unknown command handler and tests

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -479,6 +479,13 @@ async def help_command(update: Update, context: ContextTypes.DEFAULT_TYPE):
     await update.message.reply_text(text)
 
 
+@log_command
+async def unknown(update: Update, context: ContextTypes.DEFAULT_TYPE):
+    """Reply to unrecognized commands."""
+    ensure_lang(context, update.effective_user.id)
+    await update.message.reply_text('/help')
+
+
 async def error_handler(update: object, context: ContextTypes.DEFAULT_TYPE) -> None:
     """Log unexpected errors with context information."""
     user_id = None
@@ -531,6 +538,7 @@ def main(token: str | None = None):
     app.add_handler(CommandHandler('resend', resend))
     app.add_handler(CommandHandler('stats', stats))
     app.add_handler(CommandHandler('help', help_command))
+    app.add_handler(MessageHandler(filters.COMMAND, unknown))
 
     app.add_error_handler(error_handler)
 

--- a/tests/test_admin_commands.py
+++ b/tests/test_admin_commands.py
@@ -1,0 +1,75 @@
+import sys
+from pathlib import Path
+import types
+import asyncio
+import os
+
+os.environ.setdefault("ADMIN_ID", "1")
+os.environ.setdefault("ADMIN_PHONE", "+111")
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from bot import approve, deleteproduct, resend, unknown, data, ADMIN_ID  # noqa: E402
+
+
+class DummyBot:
+    def __init__(self):
+        self.sent = []
+
+    async def send_message(self, uid, text):
+        self.sent.append((uid, text))
+
+
+class DummyUpdate:
+    def __init__(self, user_id, text="/cmd"):
+        self.message = types.SimpleNamespace(
+            from_user=types.SimpleNamespace(id=user_id),
+            reply_text=self._reply,
+            text=text,
+        )
+        self.effective_user = self.message.from_user
+        self.replies = []
+
+    async def _reply(self, text):
+        self.replies.append(text)
+
+
+class DummyContext:
+    def __init__(self, args):
+        self.args = args
+        self.user_data = {}
+        self.bot = DummyBot()
+
+
+def test_approve_moves_pending():
+    data['pending'] = [{'user_id': 2, 'product_id': 'p1', 'file_id': 'f'}]
+    data['products'] = {'p1': {'price': '1', 'username': 'u', 'password': 'p', 'secret': 's', 'buyers': []}}
+    update = DummyUpdate(ADMIN_ID)
+    context = DummyContext(['2', 'p1'])
+    asyncio.run(approve(update, context))
+    assert data['pending'] == []
+    assert 2 in data['products']['p1']['buyers']
+    assert len(context.bot.sent) == 2
+
+
+def test_deleteproduct_removes_entry():
+    data['products'] = {'p1': {'price': '1', 'username': 'u', 'password': 'p', 'secret': 's'}}
+    update = DummyUpdate(ADMIN_ID)
+    context = DummyContext(['p1'])
+    asyncio.run(deleteproduct(update, context))
+    assert 'p1' not in data['products']
+
+
+def test_resend_sends_credentials():
+    data['products'] = {'p1': {'price': '1', 'username': 'u', 'password': 'p', 'secret': 's', 'buyers': [2]}}
+    update = DummyUpdate(ADMIN_ID)
+    context = DummyContext(['p1'])
+    asyncio.run(resend(update, context))
+    assert len(context.bot.sent) == 2
+    assert context.bot.sent[0][0] == 2
+
+
+def test_unknown_replies_help():
+    update = DummyUpdate(5, text="/doesnotexist")
+    context = DummyContext([])
+    asyncio.run(unknown(update, context))
+    assert update.replies == ['/help']


### PR DESCRIPTION
## Summary
- add handler for unrecognized commands returning `/help`
- register the new handler in the app
- create comprehensive tests for admin actions and unknown commands

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687171720364832d9c2dfdd455a2b083