### PR TITLE
Add encrypted storage for credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,9 +52,13 @@ Example adding a product with a name:
    ```
 
    Set the following environment variables **before running the bot**. The
-   application will exit if either is missing or invalid:
+   application will exit if any is missing or invalid:
    - `ADMIN_ID` – Telegram user ID of the admin (integer)
    - `ADMIN_PHONE` – phone number shown when users run `/contact`
+   - `FERNET_KEY` – encryption key for credentials (generate with
+     `python -c 'from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())'`)
+   Keep this key secret and consistent. Changing it will make existing
+   `data.json` contents unreadable.
 3. Run the bot with your bot token. Pass it as an argument or via the
    `BOT_TOKEN` environment variable:
    ```bash

--- a/bot.py
+++ b/bot.py
@@ -41,8 +41,13 @@ if not ADMIN_PHONE:
     logger.error("ADMIN_PHONE environment variable not set")
     raise SystemExit("ADMIN_PHONE environment variable not set")
 
+FERNET_KEY = os.environ.get("FERNET_KEY")
+if not FERNET_KEY:
+    logger.error("FERNET_KEY environment variable not set")
+    raise SystemExit("FERNET_KEY environment variable not set")
 
-storage = JSONStorage(DATA_FILE)
+
+storage = JSONStorage(DATA_FILE, FERNET_KEY.encode())
 data = asyncio.run(storage.load())
 data.setdefault('languages', {})
 

--- a/botlib/storage.py
+++ b/botlib/storage.py
@@ -4,6 +4,8 @@ import logging
 import os
 from pathlib import Path
 from typing import Any, Dict
+import copy
+from cryptography.fernet import Fernet, InvalidToken
 
 logger = logging.getLogger(__name__)
 
@@ -11,18 +13,41 @@ DEFAULT_DATA = {"products": {}, "pending": [], "languages": {}}
 
 
 class JSONStorage:
-    """Simple JSON file storage with an async lock."""
+    """Simple JSON file storage with an async lock and Fernet encryption."""
 
-    def __init__(self, path: Path):
+    def __init__(self, path: Path, key: bytes):
         self.path = path
         self.lock = asyncio.Lock()
+        self.fernet = Fernet(key)
+
+    def _encrypt_data(self, data: Dict[str, Any]) -> Dict[str, Any]:
+        encrypted = copy.deepcopy(data)
+        for product in encrypted.get("products", {}).values():
+            for field in ("username", "password", "secret"):
+                value = product.get(field)
+                if value is not None:
+                    product[field] = self.fernet.encrypt(value.encode()).decode()
+        return encrypted
+
+    def _decrypt_data(self, data: Dict[str, Any]) -> Dict[str, Any]:
+        for product in data.get("products", {}).values():
+            for field in ("username", "password", "secret"):
+                value = product.get(field)
+                if value is not None:
+                    try:
+                        product[field] = self.fernet.decrypt(value.encode()).decode()
+                    except InvalidToken:
+                        logger.error("Failed to decrypt %s", field)
+                        product[field] = ""
+        return data
 
     async def load(self) -> Dict[str, Any]:
         """Load data from the JSON file, returning defaults on error."""
         async with self.lock:
             try:
                 with open(self.path, "r") as fh:
-                    return json.load(fh)
+                    data = json.load(fh)
+                return self._decrypt_data(data)
             except FileNotFoundError:
                 return DEFAULT_DATA.copy()
             except (OSError, json.JSONDecodeError) as exc:
@@ -34,8 +59,9 @@ class JSONStorage:
         async with self.lock:
             tmp = self.path.with_suffix(".tmp")
             try:
+                enc = self._encrypt_data(data)
                 with open(tmp, "w") as fh:
-                    json.dump(data, fh, indent=2)
+                    json.dump(enc, fh, indent=2)
                 os.replace(tmp, self.path)
             except OSError as exc:
                 logger.error("Failed to save %s: %s", self.path, exc)

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ python-telegram-bot==20.6
 pyotp
 flake8
 pytest
+cryptography

--- a/tests/test_admin_commands.py
+++ b/tests/test_admin_commands.py
@@ -6,6 +6,7 @@ import os
 
 os.environ.setdefault("ADMIN_ID", "1")
 os.environ.setdefault("ADMIN_PHONE", "+111")
+os.environ.setdefault("FERNET_KEY", "MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDA=")
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 from bot import approve, deleteproduct, resend, unknown, data, ADMIN_ID  # noqa: E402

--- a/tests/test_editproduct.py
+++ b/tests/test_editproduct.py
@@ -6,6 +6,7 @@ import os
 
 os.environ.setdefault("ADMIN_ID", "1")
 os.environ.setdefault("ADMIN_PHONE", "+111")
+os.environ.setdefault("FERNET_KEY", "MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDA=")
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 from bot import editproduct, data, ADMIN_ID  # noqa: E402

--- a/tests/test_reject.py
+++ b/tests/test_reject.py
@@ -6,6 +6,7 @@ import os
 
 os.environ.setdefault("ADMIN_ID", "1")
 os.environ.setdefault("ADMIN_PHONE", "+111")
+os.environ.setdefault("FERNET_KEY", "MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDA=")
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 from bot import reject, data, ADMIN_ID  # noqa: E402

--- a/tests/test_token.py
+++ b/tests/test_token.py
@@ -2,6 +2,9 @@ import sys
 from pathlib import Path
 import pytest
 
+import os
+os.environ.setdefault("FERNET_KEY", "MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDA=")
+
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 from bot import get_bot_token  # noqa: E402
 


### PR DESCRIPTION
## Summary
- add `cryptography` to dependencies
- encrypt username/password/secret using Fernet
- require `FERNET_KEY` env variable
- document how to generate and manage the key
- update tests for new env variable

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68717298f690832db69e84793f74a2df