### PR TITLE
Add menu callback with inline keyboard

### DIFF
--- a/botlib/translations.py
+++ b/botlib/translations.py
@@ -3,6 +3,18 @@ TRANSLATIONS = {
         'en': 'Welcome! Use /products to list products.',
         'fa': 'به بات خوش آمدید! برای مشاهده محصولات از /products استفاده کنید.'
     },
+    'menu_products': {
+        'en': 'Products',
+        'fa': 'محصولات'
+    },
+    'menu_contact': {
+        'en': 'Contact',
+        'fa': 'تماس'
+    },
+    'menu_help': {
+        'en': 'Help',
+        'fa': 'راهنما'
+    },
     'admin_phone': {
         'en': 'Admin phone: {phone}',
         'fa': 'شماره مدیر: {phone}'


### PR DESCRIPTION
## Summary
- show inline menu in `/start` with links to products, contact, and help
- add new `menu_callback` handler for menu navigation
- register callback handler in `main`
- provide translations for the new menu button titles

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6871762e1040832d83eb61c367b69e95