### PR TITLE
Add unauthorized reply for admin commands

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -221,6 +221,7 @@ async def approve(update: Update, context: ContextTypes.DEFAULT_TYPE):
     ensure_lang(context, update.effective_user.id)
     lang = context.user_data['lang']
     if update.message.from_user.id != ADMIN_ID:
+        await update.message.reply_text(tr('unauthorized', lang))
         return
     try:
         user_id = int(context.args[0])
@@ -276,6 +277,7 @@ async def addproduct(update: Update, context: ContextTypes.DEFAULT_TYPE):
     ensure_lang(context, update.effective_user.id)
     lang = context.user_data['lang']
     if update.message.from_user.id != ADMIN_ID:
+        await update.message.reply_text(tr('unauthorized', lang))
         return
     try:
         pid = context.args[0]
@@ -305,6 +307,7 @@ async def editproduct(update: Update, context: ContextTypes.DEFAULT_TYPE):
     ensure_lang(context, update.effective_user.id)
     lang = context.user_data['lang']
     if update.message.from_user.id != ADMIN_ID:
+        await update.message.reply_text(tr('unauthorized', lang))
         return
     try:
         pid = context.args[0]
@@ -330,6 +333,7 @@ async def deleteproduct(update: Update, context: ContextTypes.DEFAULT_TYPE):
     ensure_lang(context, update.effective_user.id)
     lang = context.user_data['lang']
     if update.message.from_user.id != ADMIN_ID:
+        await update.message.reply_text(tr('unauthorized', lang))
         return
     try:
         pid = context.args[0]
@@ -349,6 +353,7 @@ async def resend(update: Update, context: ContextTypes.DEFAULT_TYPE):
     ensure_lang(context, update.effective_user.id)
     lang = context.user_data['lang']
     if update.message.from_user.id != ADMIN_ID:
+        await update.message.reply_text(tr('unauthorized', lang))
         return
     try:
         pid = context.args[0]
@@ -385,6 +390,7 @@ async def stats(update: Update, context: ContextTypes.DEFAULT_TYPE):
     ensure_lang(context, update.effective_user.id)
     lang = context.user_data['lang']
     if update.message.from_user.id != ADMIN_ID:
+        await update.message.reply_text(tr('unauthorized', lang))
         return
     try:
         pid = context.args[0]
@@ -411,6 +417,7 @@ async def pending(update: Update, context: ContextTypes.DEFAULT_TYPE):
     ensure_lang(context, update.effective_user.id)
     lang = context.user_data['lang']
     if update.message.from_user.id != ADMIN_ID:
+        await update.message.reply_text(tr('unauthorized', lang))
         return
     if not data['pending']:
         await update.message.reply_text(tr('no_pending', lang))
@@ -431,6 +438,7 @@ async def reject(update: Update, context: ContextTypes.DEFAULT_TYPE):
     ensure_lang(context, update.effective_user.id)
     lang = context.user_data['lang']
     if update.message.from_user.id != ADMIN_ID:
+        await update.message.reply_text(tr('unauthorized', lang))
         return
     try:
         user_id = int(context.args[0])
@@ -452,6 +460,7 @@ async def buyers(update: Update, context: ContextTypes.DEFAULT_TYPE):
     ensure_lang(context, update.effective_user.id)
     lang = context.user_data['lang']
     if update.message.from_user.id != ADMIN_ID:
+        await update.message.reply_text(tr('unauthorized', lang))
         return
     try:
         pid = context.args[0]
@@ -474,6 +483,7 @@ async def deletebuyer(update: Update, context: ContextTypes.DEFAULT_TYPE):
     ensure_lang(context, update.effective_user.id)
     lang = context.user_data['lang']
     if update.message.from_user.id != ADMIN_ID:
+        await update.message.reply_text(tr('unauthorized', lang))
         return
     try:
         pid = context.args[0]
@@ -498,6 +508,7 @@ async def clearbuyers(update: Update, context: ContextTypes.DEFAULT_TYPE):
     ensure_lang(context, update.effective_user.id)
     lang = context.user_data['lang']
     if update.message.from_user.id != ADMIN_ID:
+        await update.message.reply_text(tr('unauthorized', lang))
         return
     try:
         pid = context.args[0]

--- a/botlib/translations.py
+++ b/botlib/translations.py
@@ -43,6 +43,10 @@ TRANSLATIONS = {
         'en': 'Approved.',
         'fa': 'تایید شد.'
     },
+    'unauthorized': {
+        'en': 'Unauthorized',
+        'fa': 'اجازه دسترسی ندارید'
+    },
     'pending_not_found': {
         'en': 'Pending purchase not found.',
         'fa': 'خرید در انتظار یافت نشد.'

--- a/tests/test_admin_commands.py
+++ b/tests/test_admin_commands.py
@@ -3,6 +3,7 @@ from pathlib import Path
 import types
 import asyncio
 import os
+import pytest
 
 os.environ.setdefault("ADMIN_ID", "1")
 os.environ.setdefault("ADMIN_PHONE", "+111")
@@ -74,3 +75,19 @@ def test_unknown_replies_help():
     context = DummyContext([])
     asyncio.run(unknown(update, context))
     assert update.replies == ['/help']
+
+
+@pytest.mark.parametrize(
+    "cmd,args",
+    [
+        (approve, ['2', 'p1']),
+        (deleteproduct, ['p1']),
+        (resend, ['p1']),
+    ],
+)
+def test_non_admin_gets_unauthorized(cmd, args):
+    data.setdefault('products', {'p1': {'price': '1', 'username': 'u', 'password': 'p', 'secret': 's', 'buyers': [2]}})
+    update = DummyUpdate(5)
+    context = DummyContext(args)
+    asyncio.run(cmd(update, context))
+    assert update.replies == ['Unauthorized']

--- a/tests/test_editproduct.py
+++ b/tests/test_editproduct.py
@@ -39,3 +39,13 @@ def test_editproduct_updates_name():
     context = DummyContext(['p1', 'name', 'New', 'Name'])
     asyncio.run(editproduct(update, context))
     assert data['products']['p1']['name'] == 'New Name'
+
+
+def test_editproduct_unauthorized():
+    data['products'] = {
+        'p1': {'price': '1', 'username': 'u', 'password': 'p', 'secret': 's'}
+    }
+    update = DummyUpdate(5)
+    context = DummyContext(['p1', 'price', '2'])
+    asyncio.run(editproduct(update, context))
+    assert update.replies == ['Unauthorized']

--- a/tests/test_reject.py
+++ b/tests/test_reject.py
@@ -38,3 +38,12 @@ def test_reject_removes_pending():
     context = DummyContext(['42', 'p1'])
     asyncio.run(reject(update, context))
     assert data['pending'] == []
+
+
+def test_reject_unauthorized():
+    data['pending'] = [{'user_id': 42, 'product_id': 'p1', 'file_id': 'f'}]
+    update = DummyUpdate(5)
+    context = DummyContext(['42', 'p1'])
+    asyncio.run(reject(update, context))
+    assert update.replies == ['Unauthorized']
+    assert data['pending'] == [{'user_id': 42, 'product_id': 'p1', 'file_id': 'f'}]

--- a/tests/test_translations.py
+++ b/tests/test_translations.py
@@ -15,3 +15,8 @@ def test_tr_product_not_found():
 
 def test_tr_default_english():
     assert tr('welcome', 'en') == 'Welcome! Use /products to list products.'
+
+
+def test_tr_unauthorized():
+    assert tr('unauthorized', 'en') == 'Unauthorized'
+    assert tr('unauthorized', 'fa') == 'اجازه دسترسی ندارید'


### PR DESCRIPTION
## Summary
- reply with an unauthorized message if a non-admin user tries an admin command
- translate `unauthorized` message for English and Farsi
- test unauthorized translations and ensure admin commands return this message for non-admins

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6871772742fc832d8e80a519bd7cc4d1