### PR TITLE
Add language validation and tests

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -19,6 +19,9 @@ import pyotp
 from botlib.translations import tr
 from botlib.storage import JSONStorage
 
+# Languages that can be used with /setlang
+SUPPORTED_LANGS = {"en", "fa"}
+
 logger = logging.getLogger("accounts_bot")
 logging.basicConfig(
     format="%(asctime)s %(name)s %(levelname)s: %(message)s",
@@ -109,6 +112,9 @@ async def setlang(update: Update, context: ContextTypes.DEFAULT_TYPE):
         lang_code = context.args[0].lower()
     except IndexError:
         await update.message.reply_text(tr('setlang_usage', lang))
+        return
+    if lang_code not in SUPPORTED_LANGS:
+        await update.message.reply_text(tr('unsupported_language', lang))
         return
     data.setdefault('languages', {})[str(update.effective_user.id)] = lang_code
     await storage.save(data)

--- a/botlib/translations.py
+++ b/botlib/translations.py
@@ -95,6 +95,10 @@ TRANSLATIONS = {
         'en': 'Language updated.',
         'fa': 'زبان به روز شد.'
     },
+    'unsupported_language': {
+        'en': 'Unsupported language code.',
+        'fa': 'کد زبان پشتیبانی نمی‌شود.'
+    },
     'addproduct_usage': {
         'en': 'Usage: /addproduct <id> <price> <username> <password> <secret> [name]',
         'fa': 'استفاده: /addproduct <id> <price> <username> <password> <secret> [name]'

--- a/tests/test_setlang.py
+++ b/tests/test_setlang.py
@@ -1,0 +1,52 @@
+import sys
+from pathlib import Path
+import types
+import asyncio
+import os
+
+os.environ.setdefault("ADMIN_ID", "1")
+os.environ.setdefault("ADMIN_PHONE", "+111")
+os.environ.setdefault("FERNET_KEY", "MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDA=")
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from bot import setlang, data  # noqa: E402
+from botlib.translations import tr  # noqa: E402
+
+
+class DummyUpdate:
+    def __init__(self, user_id):
+        self.message = types.SimpleNamespace(
+            from_user=types.SimpleNamespace(id=user_id),
+            reply_text=self._reply,
+        )
+        self.effective_user = self.message.from_user
+        self.replies = []
+
+    async def _reply(self, text):
+        self.replies.append(text)
+
+
+class DummyContext:
+    def __init__(self, args):
+        self.args = args
+        self.user_data = {}
+
+
+def test_setlang_valid():
+    data['languages'] = {}
+    update = DummyUpdate(42)
+    context = DummyContext(['fa'])
+    asyncio.run(setlang(update, context))
+    assert context.user_data['lang'] == 'fa'
+    assert data['languages']['42'] == 'fa'
+    assert update.replies == [tr('language_set', 'fa')]
+
+
+def test_setlang_invalid():
+    data['languages'] = {}
+    update = DummyUpdate(42)
+    context = DummyContext(['zz'])
+    asyncio.run(setlang(update, context))
+    assert context.user_data['lang'] == 'en'
+    assert '42' not in data['languages']
+    assert update.replies == [tr('unsupported_language', 'en')]


### PR DESCRIPTION
## Summary
- restrict /setlang to supported languages
- translate new unsupported language error
- test setlang with valid and invalid codes

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687178a56a80832d80d5c125cec7b0bc