### PR TITLE
Prevent overwriting products in /addproduct

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -295,6 +295,9 @@ async def addproduct(update: Update, context: ContextTypes.DEFAULT_TYPE):
         await update.message.reply_text(tr('addproduct_usage', lang))
         return
     name = " ".join(context.args[5:]) if len(context.args) > 5 else None
+    if pid in data['products']:
+        await update.message.reply_text(tr('product_exists', lang))
+        return
     data['products'][pid] = {
         'price': price,
         'username': username,

--- a/botlib/translations.py
+++ b/botlib/translations.py
@@ -103,6 +103,10 @@ TRANSLATIONS = {
         'en': 'Usage: /addproduct <id> <price> <username> <password> <secret> [name]',
         'fa': 'استفاده: /addproduct <id> <price> <username> <password> <secret> [name]'
     },
+    'product_exists': {
+        'en': 'Product already exists',
+        'fa': 'محصول از قبل وجود دارد'
+    },
     'product_added': {
         'en': 'Product added',
         'fa': 'محصول اضافه شد'

--- a/tests/test_addproduct.py
+++ b/tests/test_addproduct.py
@@ -1,0 +1,53 @@
+import sys
+from pathlib import Path
+import types
+import asyncio
+import os
+
+os.environ.setdefault("ADMIN_ID", "1")
+os.environ.setdefault("ADMIN_PHONE", "+111")
+os.environ.setdefault("FERNET_KEY", "MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDA=")
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from bot import addproduct, data, ADMIN_ID  # noqa: E402
+from botlib.translations import tr  # noqa: E402
+
+
+class DummyUpdate:
+    def __init__(self, user_id):
+        self.message = types.SimpleNamespace(
+            from_user=types.SimpleNamespace(id=user_id),
+            reply_text=self._reply,
+        )
+        self.effective_user = self.message.from_user
+        self.replies = []
+
+    async def _reply(self, text):
+        self.replies.append(text)
+
+
+class DummyContext:
+    def __init__(self, args):
+        self.args = args
+        self.user_data = {}
+
+
+def test_addproduct_duplicate_not_overwritten():
+    data['products'] = {
+        'p1': {
+            'price': '1',
+            'username': 'u',
+            'password': 'p',
+            'secret': 's',
+            'buyers': []
+        }
+    }
+    update = DummyUpdate(ADMIN_ID)
+    context = DummyContext(['p1', '2', 'nu', 'np', 'ns'])
+    asyncio.run(addproduct(update, context))
+    assert update.replies == [tr('product_exists', 'en')]
+    assert data['products']['p1']['price'] == '1'
+    assert data['products']['p1']['username'] == 'u'
+    assert data['products']['p1']['password'] == 'p'
+    assert data['products']['p1']['secret'] == 's'
+


### PR DESCRIPTION
## Summary
- avoid overwriting existing products when running `/addproduct`
- translate new `product_exists` message
- test that duplicate product ids are rejected

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687179a5d0a4832d98323be220892747