### PR TITLE
Improve test fallback for missing telegram

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,3 +108,6 @@ Run code style checks and tests with the following commands:
 flake8
 pytest
 ```
+The unit tests require `python-telegram-bot`. Tests depending on it are skipped
+automatically when the package is missing so the suite can run without the
+dependency.

--- a/tests/test_addproduct.py
+++ b/tests/test_addproduct.py
@@ -3,10 +3,13 @@ from pathlib import Path
 import types
 import asyncio
 import os
+import pytest
 
 os.environ.setdefault("ADMIN_ID", "1")
 os.environ.setdefault("ADMIN_PHONE", "+111")
 os.environ.setdefault("FERNET_KEY", "MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDA=")
+
+pytest.importorskip("telegram")
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 from bot import addproduct, data, ADMIN_ID  # noqa: E402

--- a/tests/test_admin_commands.py
+++ b/tests/test_admin_commands.py
@@ -9,6 +9,8 @@ os.environ.setdefault("ADMIN_ID", "1")
 os.environ.setdefault("ADMIN_PHONE", "+111")
 os.environ.setdefault("FERNET_KEY", "MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDA=")
 
+pytest.importorskip("telegram")
+
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 from bot import approve, deleteproduct, resend, unknown, data, ADMIN_ID  # noqa: E402
 

--- a/tests/test_editproduct.py
+++ b/tests/test_editproduct.py
@@ -3,10 +3,13 @@ from pathlib import Path
 import types
 import asyncio
 import os
+import pytest
 
 os.environ.setdefault("ADMIN_ID", "1")
 os.environ.setdefault("ADMIN_PHONE", "+111")
 os.environ.setdefault("FERNET_KEY", "MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDA=")
+
+pytest.importorskip("telegram")
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 from bot import editproduct, data, ADMIN_ID  # noqa: E402

--- a/tests/test_reject.py
+++ b/tests/test_reject.py
@@ -3,10 +3,13 @@ from pathlib import Path
 import types
 import asyncio
 import os
+import pytest
 
 os.environ.setdefault("ADMIN_ID", "1")
 os.environ.setdefault("ADMIN_PHONE", "+111")
 os.environ.setdefault("FERNET_KEY", "MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDA=")
+
+pytest.importorskip("telegram")
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 from bot import reject, data, ADMIN_ID  # noqa: E402

--- a/tests/test_setlang.py
+++ b/tests/test_setlang.py
@@ -3,10 +3,13 @@ from pathlib import Path
 import types
 import asyncio
 import os
+import pytest
 
 os.environ.setdefault("ADMIN_ID", "1")
 os.environ.setdefault("ADMIN_PHONE", "+111")
 os.environ.setdefault("FERNET_KEY", "MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDA=")
+
+pytest.importorskip("telegram")
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 from bot import setlang, data  # noqa: E402

--- a/tests/test_token.py
+++ b/tests/test_token.py
@@ -1,9 +1,28 @@
 import sys
 from pathlib import Path
 import pytest
+import types
+import importlib.util
 
 import os
 os.environ.setdefault("FERNET_KEY", "MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDA=")
+
+if importlib.util.find_spec("telegram") is None:
+    telegram = types.ModuleType("telegram")
+    dummy = type("_Dummy", (), {})
+    telegram.Update = dummy
+    telegram.InlineKeyboardButton = dummy
+    telegram.InlineKeyboardMarkup = dummy
+    ext = types.ModuleType("telegram.ext")
+    ext.Application = dummy
+    ext.CommandHandler = dummy
+    ext.ContextTypes = types.SimpleNamespace(DEFAULT_TYPE=dummy)
+    ext.MessageHandler = dummy
+    ext.filters = types.SimpleNamespace(PHOTO=None)
+    ext.CallbackQueryHandler = dummy
+    telegram.ext = ext
+    sys.modules["telegram"] = telegram
+    sys.modules["telegram.ext"] = ext
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 from bot import get_bot_token  # noqa: E402


### PR DESCRIPTION
## Summary
- skip or mock telegram in tests when the library is missing
- mention this test behavior in the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68717aa87c1c832d8d98180dc2c69dd2