### PR TITLE
Implement admin inline interface

### DIFF
--- a/botlib/translations.py
+++ b/botlib/translations.py
@@ -15,6 +15,10 @@ TRANSLATIONS = {
         'en': 'Help',
         'fa': 'راهنما'
     },
+    'menu_pending': {
+        'en': 'Pending',
+        'fa': 'در انتظار'
+    },
     'admin_phone': {
         'en': 'Admin phone: {phone}',
         'fa': 'شماره مدیر: {phone}'
@@ -66,6 +70,14 @@ TRANSLATIONS = {
     'rejected': {
         'en': 'Purchase rejected.',
         'fa': 'خرید رد شد.'
+    },
+    'approve_button': {
+        'en': 'Approve',
+        'fa': 'تایید'
+    },
+    'reject_button': {
+        'en': 'Reject',
+        'fa': 'رد'
     },
     'code_usage': {
         'en': 'Usage: /code <product_id>',

--- a/tests/test_addproduct.py
+++ b/tests/test_addproduct.py
@@ -53,4 +53,3 @@ def test_addproduct_duplicate_not_overwritten():
     assert data['products']['p1']['username'] == 'u'
     assert data['products']['p1']['password'] == 'p'
     assert data['products']['p1']['secret'] == 's'
-

--- a/tests/test_admin_inline.py
+++ b/tests/test_admin_inline.py
@@ -1,0 +1,96 @@
+import sys
+from pathlib import Path
+import types
+import asyncio
+import os
+import pytest
+
+os.environ.setdefault("ADMIN_ID", "1")
+os.environ.setdefault("ADMIN_PHONE", "+111")
+os.environ.setdefault("FERNET_KEY", "MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDA=")
+
+pytest.importorskip("telegram")
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from bot import admin_callback, start, data, ADMIN_ID  # noqa: E402
+from botlib.translations import tr  # noqa: E402
+
+
+class DummyBot:
+    def __init__(self):
+        self.sent = []
+
+    async def send_message(self, uid, text):
+        self.sent.append((uid, text))
+
+
+class DummyCallbackUpdate:
+    def __init__(self, user_id, data):
+        self.replies = []
+
+        async def reply(text, reply_markup=None):
+            self.replies.append((text, reply_markup))
+
+        async def answer():
+            pass
+
+        self.callback_query = types.SimpleNamespace(
+            data=data,
+            message=types.SimpleNamespace(reply_text=reply),
+            from_user=types.SimpleNamespace(id=user_id),
+            answer=answer,
+        )
+        self.effective_user = self.callback_query.from_user
+        self.message = None
+
+
+class DummyContext:
+    def __init__(self):
+        self.args = []
+        self.user_data = {}
+        self.bot = DummyBot()
+
+
+class DummyMessageUpdate:
+    def __init__(self, user_id):
+        self.replies = []
+
+        async def reply(text, reply_markup=None):
+            self.replies.append((text, reply_markup))
+
+        self.message = types.SimpleNamespace(
+            from_user=types.SimpleNamespace(id=user_id),
+            reply_text=reply,
+        )
+        self.effective_user = self.message.from_user
+
+
+def test_admin_pending_list():
+    data['pending'] = [{'user_id': 2, 'product_id': 'p1', 'file_id': 'f'}]
+    update = DummyCallbackUpdate(ADMIN_ID, 'admin:pending')
+    context = DummyContext()
+    asyncio.run(admin_callback(update, context))
+    text, markup = update.replies[0]
+    assert tr('pending_entry', 'en').format(user_id=2, product_id='p1') == text
+    assert markup.inline_keyboard[0][0].text == tr('approve_button', 'en')
+
+
+def test_admin_callback_approve():
+    data['pending'] = [{'user_id': 2, 'product_id': 'p1', 'file_id': 'f'}]
+    data['products'] = {'p1': {'price': '1', 'username': 'u', 'password': 'p', 'secret': 's', 'buyers': []}}
+    update = DummyCallbackUpdate(ADMIN_ID, 'admin:approve:2:p1')
+    context = DummyContext()
+    asyncio.run(admin_callback(update, context))
+    assert data['pending'] == []
+    assert 2 in data['products']['p1']['buyers']
+    assert context.bot.sent[0][0] == 2
+
+
+def test_start_admin_keyboard():
+    update = DummyMessageUpdate(ADMIN_ID)
+    context = DummyContext()
+    asyncio.run(start(update, context))
+    markup = update.replies[0][1]
+    assert any(
+        btn.text == tr('menu_pending', 'en') for row in markup.inline_keyboard for btn in row
+    )


### PR DESCRIPTION
## Summary
- show pending management button for admins in /start
- add admin_callback handler for pending approvals
- localize new menu and buttons
- cover new callbacks with tests

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687268617bac832da73fc3b521f1ae56