### PR TITLE
Add DATA_FILE env option

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,8 @@ Example adding a product with a name:
      `python -c 'from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())'`)
    Keep this key secret and consistent. Changing it will make existing
    `data.json` contents unreadable.
+   - `DATA_FILE` – optional path to the JSON storage file. Defaults to
+     `data.json` next to `bot.py`.
 3. Run the bot with your bot token. Pass it as an argument or via the
    `BOT_TOKEN` environment variable:
    ```bash

--- a/bot.py
+++ b/bot.py
@@ -28,8 +28,9 @@ logging.basicConfig(
     level=logging.INFO,
 )
 
-# Store data.json in the same directory as this script
-DATA_FILE = Path(__file__).resolve().parent / 'data.json'
+# Data file path can be overridden via DATA_FILE env var
+DEFAULT_DATA_FILE = Path(__file__).resolve().parent / 'data.json'
+DATA_FILE = Path(os.environ.get('DATA_FILE', DEFAULT_DATA_FILE))
 try:
     ADMIN_ID = int(os.environ["ADMIN_ID"])
 except KeyError:

--- a/tests/test_datafile_env.py
+++ b/tests/test_datafile_env.py
@@ -1,0 +1,24 @@
+import sys
+from pathlib import Path
+import importlib
+import os
+import pytest
+
+# Required env vars so bot imports successfully
+os.environ.setdefault("ADMIN_ID", "1")
+os.environ.setdefault("ADMIN_PHONE", "+111")
+os.environ.setdefault("FERNET_KEY", "MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDA=")
+
+pytest.importorskip("telegram")
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+
+def test_data_file_env(monkeypatch, tmp_path):
+    custom = tmp_path / "custom.json"
+    monkeypatch.setenv("DATA_FILE", str(custom))
+    if "bot" in sys.modules:
+        del sys.modules["bot"]
+    bot = importlib.import_module("bot")
+    assert bot.DATA_FILE == custom
+    assert bot.storage.path == custom


### PR DESCRIPTION
## Summary
- allow overriding data file location via `DATA_FILE` env variable
- document new variable in README
- test custom data file path

## Testing
- `flake8`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687269d34a3c832db80034c17d1713bd