### PR TITLE
Add structured submenus with back buttons

### DIFF
--- a/botlib/translations.py
+++ b/botlib/translations.py
@@ -19,6 +19,14 @@ TRANSLATIONS = {
         'en': 'Pending',
         'fa': 'در انتظار'
     },
+    'menu_admin': {
+        'en': 'Admin',
+        'fa': 'مدیریت'
+    },
+    'menu_back': {
+        'en': 'Back',
+        'fa': 'بازگشت'
+    },
     'admin_phone': {
         'en': 'Admin phone: {phone}',
         'fa': 'شماره مدیر: {phone}'

--- a/tests/test_admin_inline.py
+++ b/tests/test_admin_inline.py
@@ -12,7 +12,7 @@ os.environ.setdefault("FERNET_KEY", "MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDA
 pytest.importorskip("telegram")
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
-from bot import admin_callback, start, data, ADMIN_ID  # noqa: E402
+from bot import admin_callback, menu_callback, start, data, ADMIN_ID  # noqa: E402
 from botlib.translations import tr  # noqa: E402
 
 
@@ -91,6 +91,17 @@ def test_start_admin_keyboard():
     context = DummyContext()
     asyncio.run(start(update, context))
     markup = update.replies[0][1]
+    assert any(
+        btn.text == tr('menu_admin', 'en') for row in markup.inline_keyboard for btn in row
+    )
+
+
+def test_admin_submenu_button():
+    update = DummyCallbackUpdate(ADMIN_ID, 'menu:admin')
+    context = DummyContext()
+    asyncio.run(menu_callback(update, context))
+    text, markup = update.replies[0]
+    assert text == tr('menu_admin', 'en')
     assert any(
         btn.text == tr('menu_pending', 'en') for row in markup.inline_keyboard for btn in row
     )


### PR DESCRIPTION
## Summary
- add `menu_admin` and `menu_back` translations
- create helper functions for building keyboards
- update `/start` to use new keyboard builder
- expand `menu_callback` to handle submenus and back
- adjust admin inline tests for new menu structure

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68726d76ed2c832db9925e125d37be8f