### PR TITLE
Enhance admin menu

### DIFF
--- a/botlib/translations.py
+++ b/botlib/translations.py
@@ -27,6 +27,18 @@ TRANSLATIONS = {
         'en': 'Back',
         'fa': 'بازگشت'
     },
+    'menu_addproduct': {
+        'en': 'Add product',
+        'fa': 'افزودن محصول'
+    },
+    'menu_editproduct': {
+        'en': 'Edit product',
+        'fa': 'ویرایش محصول'
+    },
+    'menu_stats': {
+        'en': 'Stats',
+        'fa': 'آمار'
+    },
     'admin_phone': {
         'en': 'Admin phone: {phone}',
         'fa': 'شماره مدیر: {phone}'

--- a/tests/test_admin_inline.py
+++ b/tests/test_admin_inline.py
@@ -12,7 +12,7 @@ os.environ.setdefault("FERNET_KEY", "MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDA
 pytest.importorskip("telegram")
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
-from bot import admin_callback, menu_callback, start, data, ADMIN_ID  # noqa: E402
+from bot import admin_callback, admin_menu_callback, menu_callback, start, data, ADMIN_ID  # noqa: E402
 from botlib.translations import tr  # noqa: E402
 
 
@@ -102,6 +102,26 @@ def test_admin_submenu_button():
     asyncio.run(menu_callback(update, context))
     text, markup = update.replies[0]
     assert text == tr('menu_admin', 'en')
-    assert any(
-        btn.text == tr('menu_pending', 'en') for row in markup.inline_keyboard for btn in row
-    )
+    buttons = [btn.text for row in markup.inline_keyboard for btn in row]
+    assert tr('menu_pending', 'en') in buttons
+    assert tr('menu_addproduct', 'en') in buttons
+    assert tr('menu_editproduct', 'en') in buttons
+    assert tr('menu_stats', 'en') in buttons
+
+
+def test_adminmenu_addproduct_usage():
+    update = DummyCallbackUpdate(ADMIN_ID, 'adminmenu:addproduct')
+    context = DummyContext()
+    asyncio.run(admin_menu_callback(update, context))
+    text, _ = update.replies[0]
+    assert text == tr('addproduct_usage', 'en')
+
+
+def test_adminmenu_pending_list():
+    data['pending'] = [{'user_id': 2, 'product_id': 'p1', 'file_id': 'f'}]
+    update = DummyCallbackUpdate(ADMIN_ID, 'adminmenu:pending')
+    context = DummyContext()
+    asyncio.run(admin_menu_callback(update, context))
+    text, markup = update.replies[0]
+    assert tr('pending_entry', 'en').format(user_id=2, product_id='p1') == text
+    assert markup.inline_keyboard[0][0].text == tr('approve_button', 'en')


### PR DESCRIPTION
## Summary
- extend admin submenu with buttons for add/edit/stats
- implement `admin_menu_callback`
- hook new callback into bot
- translate new menu options
- test admin submenu callbacks

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68726e87509c832dbb82bdb6b4d258dd