### PR TITLE
Add new translation keys for menus

### DIFF
--- a/botlib/translations.py
+++ b/botlib/translations.py
@@ -23,7 +23,15 @@ TRANSLATIONS = {
         'en': 'Admin',
         'fa': 'مدیریت'
     },
+    'menu_main': {
+        'en': 'Main menu',
+        'fa': 'منوی اصلی'
+    },
     'menu_back': {
+        'en': 'Back',
+        'fa': 'بازگشت'
+    },
+    'back_button': {
         'en': 'Back',
         'fa': 'بازگشت'
     },

--- a/tests/test_translations.py
+++ b/tests/test_translations.py
@@ -20,3 +20,18 @@ def test_tr_default_english():
 def test_tr_unauthorized():
     assert tr('unauthorized', 'en') == 'Unauthorized'
     assert tr('unauthorized', 'fa') == 'اجازه دسترسی ندارید'
+
+
+def test_tr_menu_admin():
+    assert tr('menu_admin', 'en') == 'Admin'
+    assert tr('menu_admin', 'fa') == 'مدیریت'
+
+
+def test_tr_menu_main():
+    assert tr('menu_main', 'en') == 'Main menu'
+    assert tr('menu_main', 'fa') == 'منوی اصلی'
+
+
+def test_tr_back_button():
+    assert tr('back_button', 'en') == 'Back'
+    assert tr('back_button', 'fa') == 'بازگشت'


### PR DESCRIPTION
## Summary
- add translations for new menu buttons: main menu and back button
- test translations for new keys

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68727009a874832d83f16db1e79ffff6