### PR TITLE
Update addproduct flow test

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -428,6 +428,9 @@ async def addproduct(update: Update, context: ContextTypes.DEFAULT_TYPE):
     if update.message.from_user.id != ADMIN_ID:
         await update.message.reply_text(tr('unauthorized', lang))
         return
+    if not context.args:
+        await update.message.reply_text(tr('ask_product_id', lang))
+        return
     try:
         pid = context.args[0]
         price = context.args[1]

--- a/tests/test_admin_inline.py
+++ b/tests/test_admin_inline.py
@@ -12,7 +12,15 @@ os.environ.setdefault("FERNET_KEY", "MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDA
 pytest.importorskip("telegram")
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
-from bot import admin_callback, admin_menu_callback, menu_callback, start, data, ADMIN_ID  # noqa: E402
+from bot import (  # noqa: E402
+    admin_callback,
+    admin_menu_callback,
+    menu_callback,
+    start,
+    addproduct,
+    data,
+    ADMIN_ID,
+)
 from botlib.translations import tr  # noqa: E402
 
 
@@ -113,8 +121,12 @@ def test_adminmenu_addproduct_usage():
     update = DummyCallbackUpdate(ADMIN_ID, 'adminmenu:addproduct')
     context = DummyContext()
     asyncio.run(admin_menu_callback(update, context))
-    text, _ = update.replies[0]
-    assert text == tr('addproduct_usage', 'en')
+
+    msg_update = DummyMessageUpdate(ADMIN_ID)
+    msg_context = DummyContext()
+    asyncio.run(addproduct(msg_update, msg_context))
+    text, _ = msg_update.replies[0]
+    assert text == tr('ask_product_id', 'en')
 
 
 def test_adminmenu_pending_list():


### PR DESCRIPTION
## Summary
- update admin inline test for add product flow
- adjust addproduct command to prompt for product id when no args

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6872783ec7b4832d940742ad5963ee84