### PR TITLE
Add addproduct conversation test and handler

### DIFF
--- a/bot_conversations.py
+++ b/bot_conversations.py
@@ -1,0 +1,86 @@
+from telegram import ReplyKeyboardMarkup, ReplyKeyboardRemove
+from telegram.ext import ConversationHandler
+
+from bot import ADMIN_ID, data, storage, ensure_lang
+
+ASK_ID, ASK_PRICE, ASK_USERNAME, ASK_PASSWORD, ASK_SECRET, ASK_NAME = range(6)
+CANCEL_TEXT = "Cancel"
+
+async def addproduct_menu(update, context):
+    ensure_lang(context, update.effective_user.id)
+    lang = context.user_data["lang"]
+    if update.effective_user.id != ADMIN_ID:
+        await update.message.reply_text("Unauthorized")
+        return ConversationHandler.END
+    await update.message.reply_text(
+        "Send product id",
+        reply_markup=ReplyKeyboardMarkup([[CANCEL_TEXT]], one_time_keyboard=True),
+    )
+    return ASK_ID
+
+async def addproduct_id(update, context):
+    if update.message.text == CANCEL_TEXT:
+        return await addproduct_cancel(update, context)
+    context.user_data["pid"] = update.message.text
+    await update.message.reply_text(
+        "Send price", reply_markup=ReplyKeyboardMarkup([[CANCEL_TEXT]], one_time_keyboard=True)
+    )
+    return ASK_PRICE
+
+async def addproduct_price(update, context):
+    if update.message.text == CANCEL_TEXT:
+        return await addproduct_cancel(update, context)
+    context.user_data["price"] = update.message.text
+    await update.message.reply_text(
+        "Send username", reply_markup=ReplyKeyboardMarkup([[CANCEL_TEXT]], one_time_keyboard=True)
+    )
+    return ASK_USERNAME
+
+async def addproduct_username(update, context):
+    if update.message.text == CANCEL_TEXT:
+        return await addproduct_cancel(update, context)
+    context.user_data["username"] = update.message.text
+    await update.message.reply_text(
+        "Send password", reply_markup=ReplyKeyboardMarkup([[CANCEL_TEXT]], one_time_keyboard=True)
+    )
+    return ASK_PASSWORD
+
+async def addproduct_password(update, context):
+    if update.message.text == CANCEL_TEXT:
+        return await addproduct_cancel(update, context)
+    context.user_data["password"] = update.message.text
+    await update.message.reply_text(
+        "Send secret", reply_markup=ReplyKeyboardMarkup([[CANCEL_TEXT]], one_time_keyboard=True)
+    )
+    return ASK_SECRET
+
+async def addproduct_secret(update, context):
+    if update.message.text == CANCEL_TEXT:
+        return await addproduct_cancel(update, context)
+    context.user_data["secret"] = update.message.text
+    await update.message.reply_text(
+        "Send name or - to skip", reply_markup=ReplyKeyboardMarkup([[CANCEL_TEXT]], one_time_keyboard=True)
+    )
+    return ASK_NAME
+
+async def addproduct_name(update, context):
+    if update.message.text == CANCEL_TEXT:
+        return await addproduct_cancel(update, context)
+    name = update.message.text
+    pid = context.user_data["pid"]
+    data["products"][pid] = {
+        "price": context.user_data["price"],
+        "username": context.user_data["username"],
+        "password": context.user_data["password"],
+        "secret": context.user_data["secret"],
+        "buyers": [],
+    }
+    if name and name != "-":
+        data["products"][pid]["name"] = name
+    await storage.save(data)
+    await update.message.reply_text("Product added", reply_markup=ReplyKeyboardRemove())
+    return ConversationHandler.END
+
+async def addproduct_cancel(update, context):
+    await update.message.reply_text("Cancelled", reply_markup=ReplyKeyboardRemove())
+    return ConversationHandler.END

--- a/tests/test_addproduct_conversation.py
+++ b/tests/test_addproduct_conversation.py
@@ -1,0 +1,115 @@
+import sys
+from pathlib import Path
+import types
+import asyncio
+import os
+import pytest
+
+# Required env vars for bot import
+os.environ.setdefault("ADMIN_ID", "1")
+os.environ.setdefault("ADMIN_PHONE", "+111")
+os.environ.setdefault("FERNET_KEY", "MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDA=")
+
+pytest.importorskip("telegram")
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from bot_conversations import (
+    addproduct_menu,
+    addproduct_id,
+    addproduct_price,
+    addproduct_username,
+    addproduct_password,
+    addproduct_secret,
+    addproduct_name,
+    addproduct_cancel,
+    ASK_ID,
+    ASK_PRICE,
+    ASK_USERNAME,
+    ASK_PASSWORD,
+    ASK_SECRET,
+    ASK_NAME,
+    CANCEL_TEXT,
+)
+from bot import data, storage, ADMIN_ID
+from telegram.ext import ConversationHandler
+
+
+class DummyUpdate:
+    def __init__(self, user_id):
+        self.message = types.SimpleNamespace(
+            from_user=types.SimpleNamespace(id=user_id),
+            reply_text=self._reply,
+            text="",
+        )
+        self.effective_user = self.message.from_user
+        self.replies = []
+
+    async def _reply(self, text, reply_markup=None):
+        self.replies.append(text)
+
+
+class DummyContext:
+    def __init__(self):
+        self.args = []
+        self.user_data = {}
+
+
+def test_addproduct_conversation(monkeypatch):
+    calls = []
+
+    async def dummy_save(d):
+        calls.append(d)
+
+    monkeypatch.setattr(storage, "save", dummy_save)
+    data["products"] = {}
+    context = DummyContext()
+    update = DummyUpdate(ADMIN_ID)
+
+    state = asyncio.run(addproduct_menu(update, context))
+    assert state == ASK_ID
+
+    update.message.text = "p1"
+    state = asyncio.run(addproduct_id(update, context))
+    assert state == ASK_PRICE
+
+    update.message.text = "1"
+    state = asyncio.run(addproduct_price(update, context))
+    assert state == ASK_USERNAME
+
+    update.message.text = "u"
+    state = asyncio.run(addproduct_username(update, context))
+    assert state == ASK_PASSWORD
+
+    update.message.text = "p"
+    state = asyncio.run(addproduct_password(update, context))
+    assert state == ASK_SECRET
+
+    update.message.text = "s"
+    state = asyncio.run(addproduct_secret(update, context))
+    assert state == ASK_NAME
+
+    update.message.text = "name"
+    state = asyncio.run(addproduct_name(update, context))
+    assert state == ConversationHandler.END
+
+    assert calls, "storage.save not called"
+    prod = data["products"].get("p1")
+    assert prod and prod["price"] == "1"
+    assert prod["username"] == "u"
+    assert prod["password"] == "p"
+    assert prod["secret"] == "s"
+    assert prod.get("name") == "name"
+
+
+def test_addproduct_cancel(monkeypatch):
+    async def dummy_save(d):
+        pass
+
+    monkeypatch.setattr(storage, "save", dummy_save)
+    context = DummyContext()
+    update = DummyUpdate(ADMIN_ID)
+
+    asyncio.run(addproduct_menu(update, context))
+    update.message.text = CANCEL_TEXT
+    state = asyncio.run(addproduct_cancel(update, context))
+    assert state == ConversationHandler.END


### PR DESCRIPTION
## Summary
- implement simple addproduct conversation handler
- test conversation flow including cancel

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6872784202b8832dab9b623cab8e70ab