### PR TITLE
Add addproduct cancel conversation test

### DIFF
--- a/bot_conversations.py
+++ b/bot_conversations.py
@@ -2,6 +2,7 @@ from telegram import ReplyKeyboardMarkup, ReplyKeyboardRemove
 from telegram.ext import ConversationHandler
 
 from bot import ADMIN_ID, data, storage, ensure_lang
+from botlib.translations import tr
 
 ASK_ID, ASK_PRICE, ASK_USERNAME, ASK_PASSWORD, ASK_SECRET, ASK_NAME = range(6)
 CANCEL_TEXT = "Cancel"
@@ -10,61 +11,86 @@ async def addproduct_menu(update, context):
     ensure_lang(context, update.effective_user.id)
     lang = context.user_data["lang"]
     if update.effective_user.id != ADMIN_ID:
-        await update.message.reply_text("Unauthorized")
+        await update.message.reply_text(tr("unauthorized", lang))
         return ConversationHandler.END
+    context.user_data["new_product"] = {}
     await update.message.reply_text(
-        "Send product id",
-        reply_markup=ReplyKeyboardMarkup([[CANCEL_TEXT]], one_time_keyboard=True),
+        tr("ask_product_id", lang),
+        reply_markup=ReplyKeyboardMarkup(
+            [[tr("cancel_button", lang)]], one_time_keyboard=True
+        ),
     )
     return ASK_ID
 
 async def addproduct_id(update, context):
-    if update.message.text == CANCEL_TEXT:
+    lang = context.user_data["lang"]
+    cancel_text = tr("cancel_button", lang)
+    if update.message.text in (CANCEL_TEXT, cancel_text, tr("back_button", lang)):
         return await addproduct_cancel(update, context)
     context.user_data["pid"] = update.message.text
+    context.user_data["new_product"]["pid"] = update.message.text
     await update.message.reply_text(
-        "Send price", reply_markup=ReplyKeyboardMarkup([[CANCEL_TEXT]], one_time_keyboard=True)
+        tr("ask_product_price", lang),
+        reply_markup=ReplyKeyboardMarkup([[cancel_text]], one_time_keyboard=True),
     )
     return ASK_PRICE
 
 async def addproduct_price(update, context):
-    if update.message.text == CANCEL_TEXT:
+    lang = context.user_data["lang"]
+    cancel_text = tr("cancel_button", lang)
+    if update.message.text in (CANCEL_TEXT, cancel_text, tr("back_button", lang)):
         return await addproduct_cancel(update, context)
     context.user_data["price"] = update.message.text
+    context.user_data["new_product"]["price"] = update.message.text
     await update.message.reply_text(
-        "Send username", reply_markup=ReplyKeyboardMarkup([[CANCEL_TEXT]], one_time_keyboard=True)
+        tr("ask_product_username", lang),
+        reply_markup=ReplyKeyboardMarkup([[cancel_text]], one_time_keyboard=True),
     )
     return ASK_USERNAME
 
 async def addproduct_username(update, context):
-    if update.message.text == CANCEL_TEXT:
+    lang = context.user_data["lang"]
+    cancel_text = tr("cancel_button", lang)
+    if update.message.text in (CANCEL_TEXT, cancel_text, tr("back_button", lang)):
         return await addproduct_cancel(update, context)
     context.user_data["username"] = update.message.text
+    context.user_data["new_product"]["username"] = update.message.text
     await update.message.reply_text(
-        "Send password", reply_markup=ReplyKeyboardMarkup([[CANCEL_TEXT]], one_time_keyboard=True)
+        tr("ask_product_password", lang),
+        reply_markup=ReplyKeyboardMarkup([[cancel_text]], one_time_keyboard=True),
     )
     return ASK_PASSWORD
 
 async def addproduct_password(update, context):
-    if update.message.text == CANCEL_TEXT:
+    lang = context.user_data["lang"]
+    cancel_text = tr("cancel_button", lang)
+    if update.message.text in (CANCEL_TEXT, cancel_text, tr("back_button", lang)):
         return await addproduct_cancel(update, context)
     context.user_data["password"] = update.message.text
+    context.user_data["new_product"]["password"] = update.message.text
     await update.message.reply_text(
-        "Send secret", reply_markup=ReplyKeyboardMarkup([[CANCEL_TEXT]], one_time_keyboard=True)
+        tr("ask_product_secret", lang),
+        reply_markup=ReplyKeyboardMarkup([[cancel_text]], one_time_keyboard=True),
     )
     return ASK_SECRET
 
 async def addproduct_secret(update, context):
-    if update.message.text == CANCEL_TEXT:
+    lang = context.user_data["lang"]
+    cancel_text = tr("cancel_button", lang)
+    if update.message.text in (CANCEL_TEXT, cancel_text, tr("back_button", lang)):
         return await addproduct_cancel(update, context)
     context.user_data["secret"] = update.message.text
+    context.user_data["new_product"]["secret"] = update.message.text
     await update.message.reply_text(
-        "Send name or - to skip", reply_markup=ReplyKeyboardMarkup([[CANCEL_TEXT]], one_time_keyboard=True)
+        tr("ask_product_name", lang),
+        reply_markup=ReplyKeyboardMarkup([[cancel_text]], one_time_keyboard=True),
     )
     return ASK_NAME
 
 async def addproduct_name(update, context):
-    if update.message.text == CANCEL_TEXT:
+    lang = context.user_data["lang"]
+    cancel_text = tr("cancel_button", lang)
+    if update.message.text in (CANCEL_TEXT, cancel_text, tr("back_button", lang)):
         return await addproduct_cancel(update, context)
     name = update.message.text
     pid = context.user_data["pid"]
@@ -77,10 +103,16 @@ async def addproduct_name(update, context):
     }
     if name and name != "-":
         data["products"][pid]["name"] = name
+        context.user_data["new_product"]["name"] = name
     await storage.save(data)
-    await update.message.reply_text("Product added", reply_markup=ReplyKeyboardRemove())
+    context.user_data.pop("new_product", None)
+    await update.message.reply_text(tr("product_added", lang), reply_markup=ReplyKeyboardRemove())
     return ConversationHandler.END
 
 async def addproduct_cancel(update, context):
-    await update.message.reply_text("Cancelled", reply_markup=ReplyKeyboardRemove())
+    lang = context.user_data.get("lang", "en")
+    context.user_data.pop("new_product", None)
+    await update.message.reply_text(
+        tr("operation_cancelled", lang), reply_markup=ReplyKeyboardRemove()
+    )
     return ConversationHandler.END

--- a/botlib/translations.py
+++ b/botlib/translations.py
@@ -127,6 +127,10 @@ TRANSLATIONS = {
         'en': 'Purchase rejected.',
         'fa': 'خرید رد شد.'
     },
+    'operation_cancelled': {
+        'en': 'Operation cancelled.',
+        'fa': 'عملیات لغو شد.'
+    },
     'approve_button': {
         'en': 'Approve',
         'fa': 'تایید'

--- a/tests/test_addproduct_conv.py
+++ b/tests/test_addproduct_conv.py
@@ -1,0 +1,59 @@
+import sys
+from pathlib import Path
+import types
+import asyncio
+import os
+import pytest
+
+# Required env vars for bot import
+os.environ.setdefault("ADMIN_ID", "1")
+os.environ.setdefault("ADMIN_PHONE", "+111")
+os.environ.setdefault("FERNET_KEY", "MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDA=")
+
+pytest.importorskip("telegram")
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from bot_conversations import (
+    addproduct_menu,
+    addproduct_cancel,
+    ASK_ID,
+)
+from bot import ADMIN_ID
+from botlib.translations import tr
+from telegram.ext import ConversationHandler
+
+
+class DummyUpdate:
+    def __init__(self, user_id):
+        self.message = types.SimpleNamespace(
+            from_user=types.SimpleNamespace(id=user_id),
+            reply_text=self._reply,
+            text="",
+        )
+        self.effective_user = self.message.from_user
+        self.replies = []
+
+    async def _reply(self, text, reply_markup=None):
+        self.replies.append(text)
+
+
+class DummyContext:
+    def __init__(self):
+        self.args = []
+        self.user_data = {}
+
+
+def test_back_button_cancels_and_clears():
+    context = DummyContext()
+    update = DummyUpdate(ADMIN_ID)
+
+    state = asyncio.run(addproduct_menu(update, context))
+    assert state == ASK_ID
+
+    lang = context.user_data["lang"]
+    update.message.text = tr("back_button", lang)
+    state = asyncio.run(addproduct_cancel(update, context))
+
+    assert state == ConversationHandler.END
+    assert "new_product" not in context.user_data
+    assert update.replies[-1] == tr("operation_cancelled", lang)


### PR DESCRIPTION
## Summary
- add translation string for operation_cancelled
- support back/cancel buttons in addproduct conversation
- clear `new_product` on cancel
- test cancelling with back button

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68728b7ca7dc832dac5cb49be8b9ea10