### PR TITLE
Improve admin edit product UI

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -287,7 +287,22 @@ async def admin_menu_callback(update: Update, context: ContextTypes.DEFAULT_TYPE
     elif action == 'addproduct':
         await query.message.reply_text(tr('addproduct_usage', lang))
     elif action == 'editproduct':
-        await query.message.reply_text(tr('editproduct_usage', lang))
+        if not data['products']:
+            await query.message.reply_text(tr('no_products', lang))
+            return
+        keyboard = [
+            [InlineKeyboardButton(pid, callback_data=f"editprod:{pid}")]
+            for pid in data['products']
+        ]
+        keyboard.append([
+            InlineKeyboardButton(
+                tr('menu_back', lang), callback_data='menu:admin'
+            )
+        ])
+        await query.message.reply_text(
+            tr('menu_editproduct', lang),
+            reply_markup=InlineKeyboardMarkup(keyboard),
+        )
     elif action == 'stats':
         await query.message.reply_text(tr('stats_usage', lang))
 

--- a/tests/test_admin_inline.py
+++ b/tests/test_admin_inline.py
@@ -137,3 +137,32 @@ def test_adminmenu_pending_list():
     text, markup = update.replies[0]
     assert tr('pending_entry', 'en').format(user_id=2, product_id='p1') == text
     assert markup.inline_keyboard[0][0].text == tr('approve_button', 'en')
+
+
+def test_adminmenu_editproduct_buttons():
+    data['products'] = {
+        'p1': {'price': '1'},
+        'p2': {'price': '2'},
+    }
+    update = DummyCallbackUpdate(ADMIN_ID, 'adminmenu:editproduct')
+    context = DummyContext()
+    asyncio.run(admin_menu_callback(update, context))
+    text, markup = update.replies[0]
+    assert text == tr('menu_editproduct', 'en')
+    callbacks = [
+        btn.callback_data
+        for row in markup.inline_keyboard
+        for btn in row
+    ]
+    assert 'editprod:p1' in callbacks
+    assert 'editprod:p2' in callbacks
+    assert markup.inline_keyboard[-1][0].callback_data == 'menu:admin'
+
+
+def test_adminmenu_editproduct_no_products():
+    data['products'] = {}
+    update = DummyCallbackUpdate(ADMIN_ID, 'adminmenu:editproduct')
+    context = DummyContext()
+    asyncio.run(admin_menu_callback(update, context))
+    text, _ = update.replies[0]
+    assert text == tr('no_products', 'en')


### PR DESCRIPTION
## Summary
- list products when choosing the admin edit-product option
- add back button to return to admin menu
- test the new edit-product inline flow

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687295f49a14832d9b7a48b0ec0033f4