### PR TITLE
Add edit product inline handler

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -308,6 +308,27 @@ async def admin_menu_callback(update: Update, context: ContextTypes.DEFAULT_TYPE
 
 
 @log_command
+async def editprod_callback(update: Update, context: ContextTypes.DEFAULT_TYPE):
+    """Show field selection buttons for editing a product."""
+    ensure_lang(context, update.effective_user.id)
+    lang = context.user_data['lang']
+    query = update.callback_query
+    await query.answer()
+    pid = query.data.split(':')[1]
+    buttons = [
+        [InlineKeyboardButton('price', callback_data=f'editfield:{pid}:price')],
+        [InlineKeyboardButton('username', callback_data=f'editfield:{pid}:username')],
+        [InlineKeyboardButton('password', callback_data=f'editfield:{pid}:password')],
+        [InlineKeyboardButton('secret', callback_data=f'editfield:{pid}:secret')],
+        [InlineKeyboardButton('name', callback_data=f'editfield:{pid}:name')],
+    ]
+    await query.message.reply_text(
+        tr('editproduct_usage', lang),
+        reply_markup=InlineKeyboardMarkup(buttons),
+    )
+
+
+@log_command
 async def handle_photo(update: Update, context: ContextTypes.DEFAULT_TYPE):
     ensure_lang(context, update.effective_user.id)
     lang = context.user_data['lang']
@@ -772,6 +793,7 @@ def main(token: str | None = None):
     app.add_handler(CallbackQueryHandler(buy_callback, pattern=r'^buy:'))
     app.add_handler(CallbackQueryHandler(admin_menu_callback, pattern=r'^adminmenu:'))
     app.add_handler(CallbackQueryHandler(admin_callback, pattern=r'^admin:'))
+    app.add_handler(CallbackQueryHandler(editprod_callback, pattern=r'^editprod:'))
     app.add_handler(MessageHandler(filters.PHOTO, handle_photo))
     app.add_handler(CommandHandler('approve', approve))
     app.add_handler(CommandHandler('reject', reject))

--- a/tests/test_admin_inline.py
+++ b/tests/test_admin_inline.py
@@ -15,6 +15,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 from bot import (  # noqa: E402
     admin_callback,
     admin_menu_callback,
+    editprod_callback,
     menu_callback,
     start,
     addproduct,
@@ -166,3 +167,24 @@ def test_adminmenu_editproduct_no_products():
     asyncio.run(admin_menu_callback(update, context))
     text, _ = update.replies[0]
     assert text == tr('no_products', 'en')
+
+
+def test_editprod_field_buttons():
+    data['products'] = {'p1': {'price': '1'}}
+    update = DummyCallbackUpdate(ADMIN_ID, 'editprod:p1')
+    context = DummyContext()
+    asyncio.run(editprod_callback(update, context))
+    _, markup = update.replies[0]
+    callbacks = [
+        btn.callback_data
+        for row in markup.inline_keyboard
+        for btn in row
+    ]
+    expected = {
+        'editfield:p1:price',
+        'editfield:p1:username',
+        'editfield:p1:password',
+        'editfield:p1:secret',
+        'editfield:p1:name',
+    }
+    assert expected.issubset(set(callbacks))


### PR DESCRIPTION
## Summary
- create `editprod_callback` to show editable fields
- register the new callback query handler in `main`
- test field button creation for `editprod` queries

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687298934de0832da1fd46458707a0a7