### PR TITLE
Add inline product edit handler

### DIFF
--- a/botlib/translations.py
+++ b/botlib/translations.py
@@ -75,6 +75,10 @@ TRANSLATIONS = {
         'en': 'Enter product name:',
         'fa': 'نام محصول را وارد کنید:'
     },
+    'ask_new_value': {
+        'en': 'Enter new value:',
+        'fa': 'مقدار جدید را وارد کنید:'
+    },
     'cancel_button': {
         'en': 'Cancel',
         'fa': 'لغو'

--- a/tests/test_editfield_flow.py
+++ b/tests/test_editfield_flow.py
@@ -1,0 +1,79 @@
+import sys
+from pathlib import Path
+import types
+import asyncio
+import os
+import pytest
+
+os.environ.setdefault("ADMIN_ID", "1")
+os.environ.setdefault("ADMIN_PHONE", "+111")
+os.environ.setdefault("FERNET_KEY", "MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDA=")
+
+pytest.importorskip("telegram")
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from bot import (
+    editfield_callback,
+    handle_edit_value,
+    data,
+    ADMIN_ID,
+)
+from botlib.translations import tr  # noqa: E402
+
+
+class DummyCallbackUpdate:
+    def __init__(self, user_id, data_str):
+        self.replies = []
+
+        async def reply(text, reply_markup=None):
+            self.replies.append((text, reply_markup))
+
+        async def answer():
+            pass
+
+        self.callback_query = types.SimpleNamespace(
+            data=data_str,
+            message=types.SimpleNamespace(reply_text=reply),
+            from_user=types.SimpleNamespace(id=user_id),
+            answer=answer,
+        )
+        self.effective_user = self.callback_query.from_user
+        self.message = None
+
+
+class DummyContext:
+    def __init__(self):
+        self.args = []
+        self.user_data = {}
+
+
+class DummyTextUpdate:
+    def __init__(self, user_id, text):
+        self.replies = []
+
+        async def reply(text, reply_markup=None):
+            self.replies.append(text)
+
+        self.message = types.SimpleNamespace(
+            from_user=types.SimpleNamespace(id=user_id),
+            reply_text=reply,
+            text=text,
+        )
+        self.effective_user = self.message.from_user
+
+
+def test_editfield_flow_updates_product():
+    data['products'] = {'p1': {'price': '1'}}
+    update = DummyCallbackUpdate(ADMIN_ID, 'editfield:p1:price')
+    context = DummyContext()
+    asyncio.run(editfield_callback(update, context))
+    assert context.user_data['edit_pid'] == 'p1'
+    assert context.user_data['edit_field'] == 'price'
+    lang = 'en'
+    assert update.replies[0][0] == tr('ask_new_value', lang)
+
+    msg_update = DummyTextUpdate(ADMIN_ID, '2')
+    asyncio.run(handle_edit_value(msg_update, context))
+    assert data['products']['p1']['price'] == '2'
+    assert msg_update.replies[0] == tr('product_updated', lang)
+    assert 'edit_pid' not in context.user_data


### PR DESCRIPTION
## Summary
- add translation prompt for editing
- implement `editfield_callback` to store product/field
- support editing via text messages
- register callback and message handler
- test inline product edit flow

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687299a929f8832d9dfed3a3871de985