### PR TITLE
Add edit flow translations

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -300,7 +300,7 @@ async def admin_menu_callback(update: Update, context: ContextTypes.DEFAULT_TYPE
             )
         ])
         await query.message.reply_text(
-            tr('menu_editproduct', lang),
+            tr('select_product_edit', lang),
             reply_markup=InlineKeyboardMarkup(keyboard),
         )
     elif action == 'stats':
@@ -323,7 +323,7 @@ async def editprod_callback(update: Update, context: ContextTypes.DEFAULT_TYPE):
         [InlineKeyboardButton('name', callback_data=f'editfield:{pid}:name')],
     ]
     await query.message.reply_text(
-        tr('editproduct_usage', lang),
+        tr('select_field_edit', lang),
         reply_markup=InlineKeyboardMarkup(buttons),
     )
 
@@ -341,7 +341,7 @@ async def editfield_callback(update: Update, context: ContextTypes.DEFAULT_TYPE)
         return
     context.user_data['edit_pid'] = pid
     context.user_data['edit_field'] = field
-    await query.message.reply_text(tr('ask_new_value', lang))
+    await query.message.reply_text(tr('enter_new_value', lang))
 
 
 @log_command

--- a/botlib/translations.py
+++ b/botlib/translations.py
@@ -187,13 +187,25 @@ TRANSLATIONS = {
         'en': 'Product added',
         'fa': 'محصول اضافه شد'
     },
+    'select_product_edit': {
+        'en': 'Select a product to edit:',
+        'fa': 'محصول مورد نظر برای ویرایش را انتخاب کنید:'
+    },
     'editproduct_usage': {
         'en': 'Usage: /editproduct <id> <field> <value> (field: price, username, password, secret, name)',
         'fa': 'استفاده: /editproduct <id> <field> <value>'
     },
+    'select_field_edit': {
+        'en': 'Select a field to edit:',
+        'fa': 'فیلد مورد نظر برای ویرایش را انتخاب کنید:'
+    },
     'invalid_field': {
         'en': 'Invalid field',
         'fa': 'فیلد نامعتبر'
+    },
+    'enter_new_value': {
+        'en': 'Enter new value:',
+        'fa': 'مقدار جدید را وارد کنید:'
     },
     'product_updated': {
         'en': 'Product updated',

--- a/tests/test_admin_inline.py
+++ b/tests/test_admin_inline.py
@@ -149,7 +149,7 @@ def test_adminmenu_editproduct_buttons():
     context = DummyContext()
     asyncio.run(admin_menu_callback(update, context))
     text, markup = update.replies[0]
-    assert text == tr('menu_editproduct', 'en')
+    assert text == tr('select_product_edit', 'en')
     callbacks = [
         btn.callback_data
         for row in markup.inline_keyboard

--- a/tests/test_editfield_flow.py
+++ b/tests/test_editfield_flow.py
@@ -70,7 +70,7 @@ def test_editfield_flow_updates_product():
     assert context.user_data['edit_pid'] == 'p1'
     assert context.user_data['edit_field'] == 'price'
     lang = 'en'
-    assert update.replies[0][0] == tr('ask_new_value', lang)
+    assert update.replies[0][0] == tr('enter_new_value', lang)
 
     msg_update = DummyTextUpdate(ADMIN_ID, '2')
     asyncio.run(handle_edit_value(msg_update, context))

--- a/tests/test_translations.py
+++ b/tests/test_translations.py
@@ -35,3 +35,12 @@ def test_tr_menu_main():
 def test_tr_back_button():
     assert tr('back_button', 'en') == 'Back'
     assert tr('back_button', 'fa') == 'بازگشت'
+
+
+def test_tr_edit_flow_strings():
+    assert tr('select_product_edit', 'en') == 'Select a product to edit:'
+    assert tr('select_product_edit', 'fa') == 'محصول مورد نظر برای ویرایش را انتخاب کنید:'
+    assert tr('select_field_edit', 'en') == 'Select a field to edit:'
+    assert tr('select_field_edit', 'fa') == 'فیلد مورد نظر برای ویرایش را انتخاب کنید:'
+    assert tr('enter_new_value', 'en') == 'Enter new value:'
+    assert tr('enter_new_value', 'fa') == 'مقدار جدید را وارد کنید:'


### PR DESCRIPTION
## Summary
- add translation keys for selecting edit product info
- use the new keys in admin inline handlers
- verify these new translations

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68729ad61a6c832d9bc7b0b1e3107198