### PR TITLE
Add inline code button workflow

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -123,6 +123,12 @@ def product_keyboard(product_id: str, lang: str) -> InlineKeyboardMarkup:
     return InlineKeyboardMarkup([[InlineKeyboardButton(tr('buy_button', lang), callback_data=f'buy:{product_id}')]])
 
 
+def code_keyboard(pid: str, lang: str) -> InlineKeyboardMarkup:
+    return InlineKeyboardMarkup(
+        [[InlineKeyboardButton(tr('code_button', lang), callback_data=f'code:{pid}')]]
+    )
+
+
 def build_back_menu(lang: str) -> InlineKeyboardMarkup:
     """Return a markup with a single back button."""
     return InlineKeyboardMarkup(
@@ -485,7 +491,11 @@ async def admin_callback(update: Update, context: ContextTypes.DEFAULT_TYPE):
                     creds = data['products'][pid]
                     msg = tr('credentials_msg', lang).format(username=creds.get('username'), password=creds.get('password'))
                     await context.bot.send_message(user_id, msg)
-                    await context.bot.send_message(user_id, tr('use_code_hint', lang).format(pid=pid))
+                    await context.bot.send_message(
+                        user_id,
+                        tr('use_code_button', lang),
+                        reply_markup=code_keyboard(pid, lang),
+                    )
                     await query.message.reply_text(tr('approved', lang))
                 else:
                     await storage.save(data)
@@ -520,7 +530,11 @@ async def approve(update: Update, context: ContextTypes.DEFAULT_TYPE):
                 password=creds.get('password'),
             )
             await context.bot.send_message(user_id, msg)
-            await context.bot.send_message(user_id, tr('use_code_hint', lang).format(pid=pid))
+            await context.bot.send_message(
+                user_id,
+                tr('use_code_button', lang),
+                reply_markup=code_keyboard(pid, lang),
+            )
             await update.message.reply_text(tr('approved', lang))
             return
     await update.message.reply_text(tr('pending_not_found', lang))
@@ -665,7 +679,11 @@ async def resend(update: Update, context: ContextTypes.DEFAULT_TYPE):
     )
     for uid in buyers:
         await context.bot.send_message(uid, msg)
-        await context.bot.send_message(uid, tr('use_code_hint', lang).format(pid=pid))
+        await context.bot.send_message(
+            uid,
+            tr('use_code_button', lang),
+            reply_markup=code_keyboard(pid, lang),
+        )
     await update.message.reply_text(tr('credentials_resent', lang))
 
 

--- a/botlib/translations.py
+++ b/botlib/translations.py
@@ -251,6 +251,14 @@ TRANSLATIONS = {
         'en': 'Use /code {pid} to get your current authenticator code.',
         'fa': 'برای دریافت کد احراز هویت، از /code {pid} استفاده کنید.'
     },
+    'code_button': {
+        'en': 'Get code',
+        'fa': 'دریافت کد'
+    },
+    'use_code_button': {
+        'en': 'Press the button to get your current authenticator code.',
+        'fa': 'برای دریافت کد احراز هویت، دکمه را بزنید.'
+    },
     'stats_usage': {
         'en': 'Usage: /stats <product_id>',
         'fa': 'استفاده: /stats <product_id>'

--- a/tests/test_admin_commands.py
+++ b/tests/test_admin_commands.py
@@ -19,7 +19,7 @@ class DummyBot:
     def __init__(self):
         self.sent = []
 
-    async def send_message(self, uid, text):
+    async def send_message(self, uid, text, reply_markup=None):
         self.sent.append((uid, text))
 
 

--- a/tests/test_admin_inline.py
+++ b/tests/test_admin_inline.py
@@ -29,7 +29,7 @@ class DummyBot:
     def __init__(self):
         self.sent = []
 
-    async def send_message(self, uid, text):
+    async def send_message(self, uid, text, reply_markup=None):
         self.sent.append((uid, text))
 
 

--- a/tests/test_menu_navigation.py
+++ b/tests/test_menu_navigation.py
@@ -21,7 +21,7 @@ class DummyBot:
     def __init__(self):
         self.sent = []
 
-    async def send_message(self, uid, text):
+    async def send_message(self, uid, text, reply_markup=None):
         self.sent.append((uid, text))
 
 

--- a/tests/test_translations.py
+++ b/tests/test_translations.py
@@ -37,6 +37,16 @@ def test_tr_back_button():
     assert tr('back_button', 'fa') == 'بازگشت'
 
 
+def test_tr_code_button():
+    assert tr('code_button', 'en') == 'Get code'
+    assert tr('code_button', 'fa') == 'دریافت کد'
+
+
+def test_tr_use_code_button():
+    assert 'Press the button' in tr('use_code_button', 'en')
+    assert tr('use_code_button', 'fa').startswith('برای دریافت')
+
+
 def test_tr_edit_flow_strings():
     assert tr('select_product_edit', 'en') == 'Select a product to edit:'
     assert tr('select_product_edit', 'fa') == 'محصول مورد نظر برای ویرایش را انتخاب کنید:'


### PR DESCRIPTION
## Summary
- include `code_button` and `use_code_button` strings for EN/FA translations
- provide `code_keyboard` helper in `bot.py`
- send new code keyboard from approve and resend paths
- adjust tests for updated bot API and verify new translations

## Testing
- `pip install -q python-telegram-bot==20.6 pyotp flake8 pytest cryptography`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6872a3cf9558832d83d40ba13593c18d