### PR TITLE
Add menu_resend translation

### DIFF
--- a/botlib/translations.py
+++ b/botlib/translations.py
@@ -63,6 +63,10 @@ TRANSLATIONS = {
         'en': 'Clear buyers',
         'fa': 'پاک‌سازی خریداران'
     },
+    'menu_resend': {
+        'en': 'Resend credentials',
+        'fa': 'ارسال مجدد اطلاعات'
+    },
     'admin_phone': {
         'en': 'Admin phone: {phone}',
         'fa': 'شماره مدیر: {phone}'

--- a/tests/test_translations.py
+++ b/tests/test_translations.py
@@ -61,3 +61,8 @@ def test_tr_new_menu_strings():
     assert tr('menu_clearbuyers', 'fa') == 'پاک‌سازی خریداران'
     assert tr('delete_button', 'en') == 'Delete'
     assert tr('select_product_stats', 'en').startswith('Select a product')
+
+
+def test_tr_menu_resend():
+    assert tr('menu_resend', 'en') == 'Resend credentials'
+    assert tr('menu_resend', 'fa') == 'ارسال مجدد اطلاعات'


### PR DESCRIPTION
## Summary
- add `menu_resend` entry to the translation table
- test english and farsi strings for the new entry

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6872d0526e1c832d8fc434d2c057f331