### PR TITLE
Add resend button in admin products menu

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -178,6 +178,7 @@ def build_products_menu(lang: str) -> InlineKeyboardMarkup:
         [InlineKeyboardButton(tr('menu_stats', lang), callback_data='adminmenu:stats')],
         [InlineKeyboardButton(tr('menu_buyers', lang), callback_data='adminmenu:buyers')],
         [InlineKeyboardButton(tr('menu_clearbuyers', lang), callback_data='adminmenu:clearbuyers')],
+        [InlineKeyboardButton(tr('menu_resend', lang), callback_data='adminmenu:resend')],
         [InlineKeyboardButton(tr('menu_back', lang), callback_data='menu:admin')],
     ]
     return InlineKeyboardMarkup(keyboard)

--- a/tests/test_menu_navigation.py
+++ b/tests/test_menu_navigation.py
@@ -141,6 +141,7 @@ def test_manage_products_submenu():
     assert 'adminmenu:stats' in callbacks
     assert 'adminmenu:buyers' in callbacks
     assert 'adminmenu:clearbuyers' in callbacks
+    assert 'adminmenu:resend' in callbacks
     assert markup.inline_keyboard[-1][0].callback_data == 'menu:admin'
 
 def test_adminmenu_addproduct_usage():


### PR DESCRIPTION
## Summary
- include a new "Resend credentials" button in `build_products_menu`
- check for `adminmenu:resend` callback in menu navigation tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6872d1863794832d901fc6a85b19ff5d