### PR TITLE
Implement resend submenu action

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -435,6 +435,22 @@ async def admin_menu_callback(update: Update, context: ContextTypes.DEFAULT_TYPE
             tr('select_product_clearbuyers', lang),
             reply_markup=InlineKeyboardMarkup(keyboard),
         )
+    elif action == 'resend':
+        if not data['products']:
+            await query.message.reply_text(
+                tr('no_products', lang),
+                reply_markup=InlineKeyboardMarkup(
+                    [[InlineKeyboardButton(tr('menu_back', lang), callback_data='adminmenu:manage')]]
+                ),
+            )
+            return
+        keyboard = [[InlineKeyboardButton(pid, callback_data=f"adminresend:{pid}")]
+                    for pid in data['products']]
+        keyboard.append([InlineKeyboardButton(tr('menu_back', lang), callback_data='adminmenu:manage')])
+        await query.message.reply_text(
+            tr('select_product_buyers', lang),
+            reply_markup=InlineKeyboardMarkup(keyboard),
+        )
 
 
 @log_command

--- a/tests/test_menu_navigation.py
+++ b/tests/test_menu_navigation.py
@@ -249,3 +249,21 @@ def test_adminmenu_clearbuyers_usage():
     asyncio.run(admin_menu_callback(back_update, back_context))
     back_text, _ = back_update.replies[0]
     assert back_text == tr('menu_manage_products', 'en')
+
+
+def test_adminmenu_resend_usage():
+    data['languages'] = {}
+    data['products'] = {'p1': {'price': '1'}}
+    update = DummyCallbackUpdate(ADMIN_ID, 'adminmenu:resend')
+    context = DummyContext()
+    asyncio.run(admin_menu_callback(update, context))
+    text, markup = update.replies[0]
+    assert text == tr('select_product_buyers', 'en')
+    callbacks = [btn.callback_data for row in markup.inline_keyboard for btn in row]
+    assert callbacks.count('adminmenu:manage') == 1
+
+    back_update = DummyCallbackUpdate(ADMIN_ID, 'adminmenu:manage')
+    back_context = DummyContext()
+    asyncio.run(admin_menu_callback(back_update, back_context))
+    back_text, _ = back_update.replies[0]
+    assert back_text == tr('menu_manage_products', 'en')


### PR DESCRIPTION
## Summary
- handle resend option in `admin_menu_callback`
- show product list when resending credentials
- test resend submenu navigation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6872d9be7e2c832dbf10465cbfd95c44