### PR TITLE
Add language selection via menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,9 @@ Users can switch their preferred language with:
 
 Replace `<code>` with a language code such as `en` or `fa`.
 
+You can also change the language from the main menu by pressing the
+"Language" button and selecting your preferred option.
+
 The `/addproduct` command accepts an optional `[name]` argument to label the product:
 
 ```bash

--- a/botlib/translations.py
+++ b/botlib/translations.py
@@ -415,6 +415,18 @@ TRANSLATIONS = {
         'en': '/stats <product_id> - show product statistics',
         'fa': '/stats <product_id> - نمایش آمار محصول'
     },
+    'menu_language': {
+        'en': 'Language',
+        'fa': 'زبان'
+    },
+    'lang_en': {
+        'en': 'English',
+        'fa': 'انگلیسی'
+    },
+    'lang_fa': {
+        'en': 'Farsi',
+        'fa': 'فارسی'
+    },
 }
 
 


### PR DESCRIPTION
## Summary
- add translation keys for language menu and names
- extend main menu with a language button
- implement `language_menu_callback` and register it
- update README docs
- test language selection via inline menu

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687393c68ffc832db7fe2e895bfdd8c3