### PR TITLE
Enable interactive product addition

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ This project contains a simple Telegram bot for selling products with manual pay
 
 ## Features
 - Admin can add products with price, credentials, TOTP secret, and an optional name.
+- Products may also be added interactively from the admin menu or by running `/addproduct` with no arguments.
 - Users can browse products and submit payment proof.
 - Admin approves purchases and credentials are sent to the buyer.
 - Buyers can obtain a current authenticator code with `/code <product_id>`.
@@ -41,6 +42,9 @@ Example adding a product with a name:
 ```bash
 /addproduct 1001 9.99 someuser somepass JBSWY3DPEHPK3PXP "My Product"
 ```
+
+Alternatively, run `/addproduct` with no arguments or choose "Add product" from
+the admin menu to add items interactively.
 
 ## Setup
 1. Install dependencies:

--- a/bot_conversations.py
+++ b/bot_conversations.py
@@ -11,11 +11,15 @@ CANCEL_TEXT = "Cancel"
 async def addproduct_menu(update, context):
     ensure_lang(context, update.effective_user.id)
     lang = context.user_data["lang"]
+    message = getattr(update, "message", None)
+    if message is None:
+        message = update.callback_query.message
+        await update.callback_query.answer()
     if update.effective_user.id != ADMIN_ID:
-        await update.message.reply_text(tr("unauthorized", lang))
+        await message.reply_text(tr("unauthorized", lang))
         return ConversationHandler.END
     context.user_data["new_product"] = {}
-    await update.message.reply_text(
+    await message.reply_text(
         tr("ask_product_id", lang),
         reply_markup=ReplyKeyboardMarkup(
             [[tr("cancel_button", lang)]], one_time_keyboard=True

--- a/tests/test_addproduct_entrypoints.py
+++ b/tests/test_addproduct_entrypoints.py
@@ -1,0 +1,74 @@
+import asyncio
+import os
+import types
+from pathlib import Path
+import sys
+import pytest
+
+os.environ.setdefault("ADMIN_ID", "1")
+os.environ.setdefault("ADMIN_PHONE", "+111")
+os.environ.setdefault("FERNET_KEY", "MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDA=")
+
+pytest.importorskip("telegram")
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))  # noqa: E402
+from bot import ADMIN_ID  # noqa: E402
+from bot_conversations import addproduct_menu, ASK_ID  # noqa: E402
+
+
+class DummyMessageUpdate:
+    def __init__(self, user_id):
+        async def reply(text, reply_markup=None):
+            self.replies.append(text)
+
+        self.message = types.SimpleNamespace(
+            from_user=types.SimpleNamespace(id=user_id),
+            reply_text=reply,
+            text="/addproduct",
+        )
+        self.effective_user = self.message.from_user
+        self.replies = []
+
+
+class DummyCallbackUpdate:
+    def __init__(self, user_id):
+        self.replies = []
+
+        async def reply(text, reply_markup=None):
+            self.replies.append(text)
+
+        async def answer():
+            self.answered = True
+
+        self.callback_query = types.SimpleNamespace(
+            data="adminmenu:addproduct",
+            message=types.SimpleNamespace(reply_text=reply),
+            from_user=types.SimpleNamespace(id=user_id),
+            answer=answer,
+        )
+        self.effective_user = self.callback_query.from_user
+        self.message = None
+        self.answered = False
+
+
+class DummyContext:
+    def __init__(self):
+        self.args = []
+        self.user_data = {}
+
+
+def test_command_entrypoint_starts_conversation():
+    context = DummyContext()
+    update = DummyMessageUpdate(ADMIN_ID)
+    state = asyncio.run(addproduct_menu(update, context))
+    assert state == ASK_ID
+    assert context.user_data["new_product"] == {}
+
+
+def test_menu_entrypoint_starts_conversation():
+    context = DummyContext()
+    update = DummyCallbackUpdate(ADMIN_ID)
+    state = asyncio.run(addproduct_menu(update, context))
+    assert state == ASK_ID
+    assert context.user_data["new_product"] == {}
+    assert update.answered

--- a/tests/test_admin_inline.py
+++ b/tests/test_admin_inline.py
@@ -21,10 +21,10 @@ from bot import (  # noqa: E402
     resend_callback,
     menu_callback,
     start,
-    addproduct,
     data,
     ADMIN_ID,
 )
+import bot_conversations  # noqa: E402
 from botlib.translations import tr  # noqa: E402
 
 
@@ -120,15 +120,12 @@ def test_admin_submenu_button():
     assert tr('menu_stats', 'en') in buttons
 
 
-def test_adminmenu_addproduct_usage():
+def test_adminmenu_addproduct_starts_conversation():
     update = DummyCallbackUpdate(ADMIN_ID, 'adminmenu:addproduct')
     context = DummyContext()
-    asyncio.run(admin_menu_callback(update, context))
-
-    msg_update = DummyMessageUpdate(ADMIN_ID)
-    msg_context = DummyContext()
-    asyncio.run(addproduct(msg_update, msg_context))
-    text, _ = msg_update.replies[0]
+    state = asyncio.run(bot_conversations.addproduct_menu(update, context))
+    assert state == bot_conversations.ASK_ID
+    text, _ = update.replies[0]
     assert text == tr('ask_product_id', 'en')
 
 

--- a/tests/test_menu_navigation.py
+++ b/tests/test_menu_navigation.py
@@ -20,6 +20,7 @@ from bot import (  # noqa: E402
     data,
     ADMIN_ID,
 )
+import bot_conversations  # noqa: E402
 from botlib.translations import tr  # noqa: E402
 
 
@@ -180,22 +181,14 @@ def test_manage_products_submenu():
     assert tr('menu_resend', 'en') in texts
 
 
-def test_adminmenu_addproduct_usage():
+def test_adminmenu_addproduct_starts_conversation():
     data['languages'] = {}
     update = DummyCallbackUpdate(ADMIN_ID, 'adminmenu:addproduct')
     context = DummyContext()
-    asyncio.run(admin_menu_callback(update, context))
-    text, markup = update.replies[0]
-    assert text == tr('addproduct_usage', 'en')
-    callbacks = [btn.callback_data for row in markup.inline_keyboard for btn in row]
-    assert callbacks == ['adminmenu:manage']
-
-    # Simulate pressing the back button
-    back_update = DummyCallbackUpdate(ADMIN_ID, 'adminmenu:manage')
-    back_context = DummyContext()
-    asyncio.run(admin_menu_callback(back_update, back_context))
-    back_text, _ = back_update.replies[0]
-    assert back_text == tr('menu_manage_products', 'en')
+    state = asyncio.run(bot_conversations.addproduct_menu(update, context))
+    assert state == bot_conversations.ASK_ID
+    text, _ = update.replies[0]
+    assert text == tr('ask_product_id', 'en')
 
 
 def test_adminmenu_editproduct_usage():


### PR DESCRIPTION
## Summary
- support starting the add-product conversation from the admin menu or `/addproduct`
- wire new ConversationHandler in `main()`
- update conversation to handle callback queries
- document interactive addition in README
- adjust existing tests and add tests for entry points

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68739703517c832d8bb1900da08fef7c