### PR TITLE
Add env fixture for tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,18 @@
+import os
+import pytest
+
+DEFAULT_ENV = {
+    "ADMIN_ID": "1",
+    "ADMIN_PHONE": "+111",
+    "FERNET_KEY": "MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDA="
+}
+
+# Ensure variables are present during test collection
+for key, value in DEFAULT_ENV.items():
+    os.environ.setdefault(key, value)
+
+@pytest.fixture(autouse=True)
+def bot_environment(monkeypatch):
+    for key, value in DEFAULT_ENV.items():
+        monkeypatch.setenv(key, value)
+    yield

--- a/tests/test_addproduct.py
+++ b/tests/test_addproduct.py
@@ -5,10 +5,6 @@ import asyncio
 import os
 import pytest
 
-os.environ.setdefault("ADMIN_ID", "1")
-os.environ.setdefault("ADMIN_PHONE", "+111")
-os.environ.setdefault("FERNET_KEY", "MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDA=")
-
 pytest.importorskip("telegram")
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))

--- a/tests/test_addproduct_conv.py
+++ b/tests/test_addproduct_conv.py
@@ -22,12 +22,7 @@ from bot import ADMIN_ID
 from botlib.translations import tr
 from telegram.ext import ConversationHandler
 
-# Required env vars for bot import
-os.environ.setdefault("ADMIN_ID", "1")
-os.environ.setdefault("ADMIN_PHONE", "+111")
-os.environ.setdefault(
-    "FERNET_KEY", "MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDA="
-)
+
 
 pytest.importorskip("telegram")
 

--- a/tests/test_addproduct_conversation.py
+++ b/tests/test_addproduct_conversation.py
@@ -24,12 +24,7 @@ from bot_conversations import (
 from bot import data, storage, ADMIN_ID
 from telegram.ext import ConversationHandler
 
-# Required env vars for bot import
-os.environ.setdefault("ADMIN_ID", "1")
-os.environ.setdefault("ADMIN_PHONE", "+111")
-os.environ.setdefault(
-    "FERNET_KEY", "MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDA="
-)
+
 
 pytest.importorskip("telegram")
 

--- a/tests/test_addproduct_entrypoints.py
+++ b/tests/test_addproduct_entrypoints.py
@@ -5,9 +5,7 @@ from pathlib import Path
 import sys
 import pytest
 
-os.environ.setdefault("ADMIN_ID", "1")
-os.environ.setdefault("ADMIN_PHONE", "+111")
-os.environ.setdefault("FERNET_KEY", "MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDA=")
+
 
 pytest.importorskip("telegram")
 

--- a/tests/test_admin_commands.py
+++ b/tests/test_admin_commands.py
@@ -5,10 +5,6 @@ import asyncio
 import os
 import pytest
 
-os.environ.setdefault("ADMIN_ID", "1")
-os.environ.setdefault("ADMIN_PHONE", "+111")
-os.environ.setdefault("FERNET_KEY", "MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDA=")
-
 pytest.importorskip("telegram")
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))

--- a/tests/test_admin_inline.py
+++ b/tests/test_admin_inline.py
@@ -5,10 +5,6 @@ import asyncio
 import os
 import pytest
 
-os.environ.setdefault("ADMIN_ID", "1")
-os.environ.setdefault("ADMIN_PHONE", "+111")
-os.environ.setdefault("FERNET_KEY", "MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDA=")
-
 pytest.importorskip("telegram")
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))

--- a/tests/test_code_button.py
+++ b/tests/test_code_button.py
@@ -6,10 +6,6 @@ import os
 import pytest
 import pyotp
 
-# Required env vars
-os.environ.setdefault("ADMIN_ID", "1")
-os.environ.setdefault("ADMIN_PHONE", "+111")
-os.environ.setdefault("FERNET_KEY", "MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDA=")
 
 pytest.importorskip("telegram")
 

--- a/tests/test_datafile_env.py
+++ b/tests/test_datafile_env.py
@@ -4,10 +4,6 @@ import importlib
 import os
 import pytest
 
-# Required env vars so bot imports successfully
-os.environ.setdefault("ADMIN_ID", "1")
-os.environ.setdefault("ADMIN_PHONE", "+111")
-os.environ.setdefault("FERNET_KEY", "MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDA=")
 
 pytest.importorskip("telegram")
 

--- a/tests/test_editfield_flow.py
+++ b/tests/test_editfield_flow.py
@@ -5,10 +5,6 @@ import asyncio
 import os
 import pytest
 
-os.environ.setdefault("ADMIN_ID", "1")
-os.environ.setdefault("ADMIN_PHONE", "+111")
-os.environ.setdefault("FERNET_KEY", "MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDA=")
-
 pytest.importorskip("telegram")
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))  # noqa: E402

--- a/tests/test_editproduct.py
+++ b/tests/test_editproduct.py
@@ -5,10 +5,6 @@ import asyncio
 import os
 import pytest
 
-os.environ.setdefault("ADMIN_ID", "1")
-os.environ.setdefault("ADMIN_PHONE", "+111")
-os.environ.setdefault("FERNET_KEY", "MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDA=")
-
 pytest.importorskip("telegram")
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))

--- a/tests/test_editproduct_conv.py
+++ b/tests/test_editproduct_conv.py
@@ -5,11 +5,6 @@ import asyncio
 import os
 import pytest
 
-# Required env vars for bot import
-os.environ.setdefault("ADMIN_ID", "1")
-os.environ.setdefault("ADMIN_PHONE", "+111")
-os.environ.setdefault("FERNET_KEY", "MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDA=")
-
 pytest.importorskip("telegram")
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))  # noqa: E402

--- a/tests/test_menu_navigation.py
+++ b/tests/test_menu_navigation.py
@@ -5,10 +5,6 @@ import asyncio
 import os
 import pytest
 
-# Ensure required env vars
-os.environ.setdefault("ADMIN_ID", "1")
-os.environ.setdefault("ADMIN_PHONE", "+111")
-os.environ.setdefault("FERNET_KEY", "MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDA=")
 
 pytest.importorskip("telegram")
 

--- a/tests/test_reject.py
+++ b/tests/test_reject.py
@@ -5,10 +5,6 @@ import asyncio
 import os
 import pytest
 
-os.environ.setdefault("ADMIN_ID", "1")
-os.environ.setdefault("ADMIN_PHONE", "+111")
-os.environ.setdefault("FERNET_KEY", "MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDA=")
-
 pytest.importorskip("telegram")
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))

--- a/tests/test_resend_callback.py
+++ b/tests/test_resend_callback.py
@@ -5,13 +5,6 @@ import asyncio
 import os
 import pytest
 
-os.environ.setdefault("ADMIN_ID", "1")
-os.environ.setdefault("ADMIN_PHONE", "+111")
-os.environ.setdefault(
-    "FERNET_KEY",
-    "MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDA="
-)
-
 pytest.importorskip("telegram")
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))

--- a/tests/test_setlang.py
+++ b/tests/test_setlang.py
@@ -5,10 +5,6 @@ import asyncio
 import os
 import pytest
 
-os.environ.setdefault("ADMIN_ID", "1")
-os.environ.setdefault("ADMIN_PHONE", "+111")
-os.environ.setdefault("FERNET_KEY", "MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDA=")
-
 pytest.importorskip("telegram")
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))

--- a/tests/test_token.py
+++ b/tests/test_token.py
@@ -5,7 +5,6 @@ import types
 import importlib.util
 
 import os
-os.environ.setdefault("FERNET_KEY", "MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDA=")
 
 if importlib.util.find_spec("telegram") is None:
     telegram = types.ModuleType("telegram")


### PR DESCRIPTION
## Summary
- add autouse fixture to set required env vars
- rely on fixture instead of setdefault blocks in tests

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6873a2c08d40832d912940bc29d4777b