### PR TITLE
Add dev extras in pyproject

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,10 @@ the admin menu to add items interactively.
    ```bash
    pip install -e .
    ```
+   For development, include optional dependencies with:
+   ```bash
+   pip install -e .[dev]
+   ```
 2. The bot stores its state in a `data.json` file located next to `bot.py`.
    **Do not commit this file.** It is excluded via `.gitignore` and will be
    created automatically on first run if it doesn't exist.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,3 +18,9 @@ dependencies = [
 [project.scripts]
 account-seller-bot = "bot:main"
 
+[project.optional-dependencies]
+dev = [
+    "flake8",
+    "pytest",
+]
+


### PR DESCRIPTION
## Summary
- add `[project.optional-dependencies]` with a `dev` section for flake8 and pytest
- explain how to install dev requirements in README

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6873ac458000832da9983aa5fc0b411e